### PR TITLE
Testing tech detect

### DIFF
--- a/http/technologies/confluence-detect.yaml
+++ b/http/technologies/confluence-detect.yaml
@@ -1,15 +1,18 @@
 id: confluence-detect
 
 info:
-  name: Confluence Detection
+  name: Atlassian Confluence - Detection
   author: philippedelteil,AdamCrosser,6mile
   severity: info
   description: |
-    This nuclei template is used to detect the presence of Confluence, a popular collaboration software.
+    Atlassian Confluence was detected.
   classification:
     cpe: cpe:2.3:a:atlassian:confluence_server:*:*:*:*:*:*:*:*
   metadata:
     max-request: 5
+    runzero-match: any(each(service["html.titles"]), {# matches "Confluence"})
+    runzero-vendor: Atlassian
+    runzero-product: Confluence
     vendor: atlassian
     product: confluence_server
     shodan-query:

--- a/http/technologies/default-lighttpd-placeholder-page.yaml
+++ b/http/technologies/default-lighttpd-placeholder-page.yaml
@@ -1,7 +1,9 @@
 id: lighttpd-placeholder-page
 
 info:
-  name: Lighttpd Placeholder Page
+  name: Lighttpd - Detection
+  description: |
+    Lighttpd was detected.
   author: idealphase
   severity: info
   classification:
@@ -11,6 +13,9 @@ info:
     vendor: lighttpd
     product: lighttpd
     shodan-query: "If you find a bug in this Lighttpd package, or in Lighttpd itself"
+    runzero-match: service["http.body"] matches "Lighttpd"
+    runzero-vendor: Lighttpd
+    runzero-product: Lighttpd
   tags: tech,lighttpd
 
 http:

--- a/http/technologies/microsoft/microsoft-iis-version.yaml
+++ b/http/technologies/microsoft/microsoft-iis-version.yaml
@@ -1,12 +1,15 @@
 id: microsoft-iis-version
 
 info:
-  name: Microsoft IIS version detect
+  name: Microsoft IIS - Detection
   author: Wlayzz
   severity: info
-  description: Some Microsoft IIS servers have the version on the response header. Useful when you need to find specific CVEs on your targets.
+  description: Microsoft IIS detected.
   metadata:
     max-request: 1
+    runzero-match: any(each(service["http.head.server"]), {# matches "IIS"})
+    runzero-vendor: Microsoft
+    runzero-product: IIS
   tags: tech,microsoft,iis
 
 
@@ -25,8 +28,9 @@ http:
           - "IIS"
 
     extractors:
-      - type: kval
-        part: header
-        kval:
-          - Server
+      - type: regex
+        name: version
+        group: 1
+        regex:
+          - 'Microsoft-IIS/([0-9.]{2,3})'
 # digest: 490a004630440220064f8cd5bc5f9ec7b7d7b2afaf0451a0a51eb2643a704bb362dd4cf5e76c5dcb022066d8dece1d0e1256f6fe41534f606dad0f638c98cd0f4408adc670382acbe0f6:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/nextcloud-detect.yaml
+++ b/http/technologies/nextcloud-detect.yaml
@@ -17,8 +17,8 @@ info:
     product: nextcloud_server
     shodan-query: http.title:"Nextcloud"
     runzero-match: any(each(service["html.titles"]), {# matches "Nextcloud"})
-    runzero-vendor: "Nextcloud"
-    runzero-product: "Nextcloud Server"
+    runzero-vendor: Nextcloud
+    runzero-product: Nextcloud Server
   tags: tech,nextcloud,storage
 
 http:

--- a/http/technologies/nextcloud-detect.yaml
+++ b/http/technologies/nextcloud-detect.yaml
@@ -1,11 +1,11 @@
 id: nextcloud-detect
 
 info:
-  name: Nextcloud Detect
+  name: Nextcloud Server - Detection
   author: skeltavik
   severity: info
   description: |
-    Nextcloud is a suite of client-server software for creating and using file hosting services
+    Nextcloud Server was detected.
   reference:
     - https://nextcloud.com
   classification:
@@ -16,6 +16,9 @@ info:
     vendor: nextcloud
     product: nextcloud_server
     shodan-query: http.title:"Nextcloud"
+    runzero-match: any(each(service["html.titles"]), {# matches "Nextcloud"})
+    runzero-vendor: "Nextcloud"
+    runzero-product: "Nextcloud Server"
   tags: tech,nextcloud,storage
 
 http:
@@ -45,6 +48,7 @@ http:
 
     extractors:
       - type: regex
+        name: version
         group: 1
         regex:
           - '(?m)"version":"([0-9.]+)",'

--- a/http/technologies/nextcloud-owncloud-detect.yaml
+++ b/http/technologies/nextcloud-owncloud-detect.yaml
@@ -16,8 +16,8 @@ info:
     shodan-query: http.html:"owncloud"
     runzero-match: |-
       any(each(service["html.titles"]), {# matches "ownCloud"})
-    runzero-vendor: "ownCloud"
-    runzero-product: "ownCloud Server"
+    runzero-vendor: ownCloud
+    runzero-product: ownCloud Server
   tags: tech,owncloud,status
 
 http:

--- a/http/technologies/nextcloud-owncloud-detect.yaml
+++ b/http/technologies/nextcloud-owncloud-detect.yaml
@@ -1,9 +1,11 @@
 id: owncloud-status-page
 
 info:
-  name: Owncloud StatusPage detection
+  name: ownCloud Server - Detection
   author: myztique,invisiblethreat
   severity: info
+  description: |
+    ownCloud Server was detected.
   classification:
     cpe: cpe:2.3:a:owncloud:owncloud:*:*:*:*:*:*:*:*
   metadata:
@@ -12,6 +14,10 @@ info:
     vendor: owncloud
     product: owncloud
     shodan-query: http.html:"owncloud"
+    runzero-match: |-
+      any(each(service["html.titles"]), {# matches "ownCloud"})
+    runzero-vendor: "ownCloud"
+    runzero-product: "ownCloud Server"
   tags: tech,owncloud,status
 
 http:
@@ -30,6 +36,7 @@ http:
 
     extractors:
       - type: json
+        name: version
         json:
           - .version
 # digest: 4a0a00473045022100d61fa1daed9fac927962a14a508d9e07567a8ef955b9fb021c679e723e10136e02206baad4e765aa8890f6bb0086ada5c9c0f78437ba5de31faac000089e34eb8866:922c64590222798bb761d5b6d8e72950

--- a/http/technologies/roundcube-webmail-portal.yaml
+++ b/http/technologies/roundcube-webmail-portal.yaml
@@ -1,7 +1,8 @@
 id: roundcube-webmail-portal
 
 info:
-  name: Roundcube webmail
+  name: Roundcube Webmail - Detection
+  description: Roundcube Webmail detected.
   author: ritikchaddha
   severity: info
   classification:
@@ -11,6 +12,9 @@ info:
     vendor: roundcube
     product: webmail
     shodan-query: http.component:"RoundCube"
+    runzero-match: any(each(service["html.titles"]), {# matches "Roundcube"})
+    runzero-vendor: Roundcube
+    runzero-product: Webmail
   tags: roundcube,portal,tech
 
 http:


### PR DESCRIPTION
Internal testing of tech detection templates.

Testing targets:
- Roundcube: `podman run --rm -it -p 8000:80 roundcube/roundcubemail`
- Confluence: `podman run  --rm -it --name="confluence"  -p 8090:8090 -p 8091:8091 atlassian/confluence`
- Nextcloud: `podman run --rm -it -p 8088:80 nextcloud`
- ownCloud:  `podman run --rm -it -e OWNCLOUD_TRUSTED_DOMAINS=YOUR_IP_HERE  -p 8090:8080 owncloud/server`