### PR TITLE
Update PAN-OS icon hash

### DIFF
--- a/http/cves/2024/CVE-2024-0012.yaml
+++ b/http/cves/2024/CVE-2024-0012.yaml
@@ -5,7 +5,7 @@ info:
   author: johnk3r,watchtowr
   severity: critical
   description: |
-    An authentication bypass in Palo Alto Networks PAN-OS software enables an unauthenticated attacker with network access to the management web interface to gain PAN-OS administrator privileges to perform administrative actions, tamper with the configuration, or exploit other authenticated privilege escalation vulnerabilities
+    An authentication bypass in Palo Alto Networks PAN-OS software enables an unauthenticated attacker with network access to the management web interface to gain PAN-OS administrator privileges to perform administrative actions, tamper with the configuration, or exploit other authenticated privilege escalation vulnerabilities.
   reference:
     - https://security.paloaltonetworks.com/CVE-2024-0012
     - https://labs.watchtowr.com/pots-and-pans-aka-an-sslvpn-palo-alto-pan-os-cve-2024-0012-and-cve-2024-9474/
@@ -28,8 +28,11 @@ info:
     shodan-query:
       - cpe:"cpe:2.3:o:paloaltonetworks:pan-os"
       - http.favicon.hash:"-631559155"
-    fofa-query: icon_hash="-631559155"
-    runzero-match: service["favicon.ico.image.mmh3"] == "-631559155"
+      - http.favicon.hash:"873381299"
+    fofa-query:
+      - icon_hash="-631559155"
+      - icon_hash="873381299"
+    runzero-match: service["favicon.ico.image.mmh3"] == "-631559155" || service["favicon.ico.image.mmh3"] == "873381299"
   tags: cve,cve2024,paloalto,globalprotect,kev
 
 http:

--- a/http/cves/2025/CVE-2025-0108.yaml
+++ b/http/cves/2025/CVE-2025-0108.yaml
@@ -5,7 +5,7 @@ info:
   author: halencarjunior,ritikchaddha
   severity: critical
   description: |
-    A vulnerability in PAN-OS management interface allows authentication bypass through path confusion between Nginx and Apache handlers.The issue occurs due to differences in path processing between Nginx and Apache, where double URL encoding combined with directory traversal can bypass authentication checks enforced by X-pan-AuthCheck header.
+    A vulnerability in PAN-OS management interface allows authentication bypass through path confusion between Nginx and Apache handlers. The issue occurs due to differences in path processing between Nginx and Apache, where double URL encoding combined with directory traversal can bypass authentication checks enforced by X-pan-AuthCheck header.
   reference:
     - https://slcyber.io/blog/nginx-apache-path-confusion-to-auth-bypass-in-pan-os/
     - https://www.bleepingcomputer.com/news/security/palo-alto-networks-tags-new-firewall-bug-as-exploited-in-attacks/
@@ -28,8 +28,11 @@ info:
     shodan-query:
       - cpe:"cpe:2.3:o:paloaltonetworks:pan-os"
       - http.favicon.hash:"-631559155"
-    fofa-query: icon_hash="-631559155"
-    runzero-match: service["favicon.ico.image.mmh3"] == "-631559155"
+      - http.favicon.hash:"873381299"
+    fofa-query:
+      - icon_hash="-631559155"
+      - icon_hash="873381299"
+    runzero-match: service["favicon.ico.image.mmh3"] == "-631559155" || service["favicon.ico.image.mmh3"] == "873381299"
   tags: cve,cve2025,panos,auth-bypass,kev
 
 http:


### PR DESCRIPTION
### Template / PR Information
- Fixed CVE-2024-0012 and CVE-2025-0108 by updating the `favicon.ico.image.mmh3` value to match additional versions/targets.

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO

This has been validated against PAN-OS versions known to be vulnerable.