### PR TITLE
Pelco Sarix Default Credential Check

### DIFF
--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -2,7 +2,7 @@ id: pelco-sarix-default-login-combined
 
 info:
   name: Pelco Sarix - Default Login (Basic and Digest)
-  author: tdiderich (modified by Gemini)
+  author: tdiderich
   severity: high
   description: |
     Pelco Sarix camera default login credentials (admin/admin) were discovered.

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -35,8 +35,7 @@ http:
         - admin
 
     stop-at-first-match: true
-    # Do not follow redirects automatically, as we want to inspect the Location header.
-    host-redirects: false
+    host-redirects: true
 
     matchers-condition: and
     matchers:

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -1,86 +1,64 @@
-id: pelco-sarix-default-login-combined
+id: pelco-sarix-default-login-digest
 
 info:
-  name: Pelco Sarix - Default Login (Basic and Digest)
+  name: Pelco Sarix - Default Login
   author: tdiderich
   severity: high
   description: |
-    Pelco Sarix camera default login credentials (admin/admin) were discovered.
-    This template attempts both Basic and Digest authentication methods.
+    Pelco Sarix camera default login credentials (admin/admin) were discovered using Digest Authentication.
   reference:
     - https://www.pelco.com/
   classification:
     cwe-id: CWE-798
   metadata:
     verified: true
-    max-request: 3 # 1 for Basic, 2 for Digest
+    max-request: 2
     vendor: pelco
     product: sarix
+    runzero-match: asset["hw"] matches "(i)Pelco Sarix"
   tags: pelco,sarix,default-login
 
 http:
-  # --- Block 1: Basic Authentication Attempt ---
-  # This will be tried first. It's for devices that don't issue a 401 challenge.
   - raw:
       - |
         GET /cgi-bin/get?system.access_level HTTP/1.1
         Host: {{Hostname}}
-        Authorization: Basic {{base64('admin' + ':' + 'admin')}}
 
-    matchers-condition: and
     matchers:
       - type: status
         status:
-          - 200
+          - 401
       - type: word
-        part: body
         words:
-          - "system.access_level"
+          - "WWW-Authenticate: Digest"
+        part: header
 
-  # --- Block 2: Digest Authentication Attempt ---
-  # This will run if the first block fails. It handles the 401 challenge/response.
-  - raw:
-      - |
-        GET /cgi-bin/get?system.access_level HTTP/1.1
-        Host: {{Hostname}}
-
-      - |
-        GET /cgi-bin/get?system.access_level HTTP/1.1
-        Host: {{Hostname}}
-        Authorization: Digest username="admin", realm="{{realm}}", nonce="{{nonce}}", uri="/cgi-bin/get?system.access_level", qop={{qop}}, nc=00000001, cnonce="{{rand_base(8)}}", response="{{md5(md5('admin:{{realm}}:admin') + ':' + nonce + ':' + '00000001' + ':' + rand_base(8) + ':' + qop + ':' + md5('GET:/cgi-bin/get?system.access_level'))}}"
-
-    attack: pitchfork
-    payloads:
-      # Dummy payload to satisfy the attack type, values are not used in the digest flow
-      username:
-        - admin
-      password:
-        - admin
-
-    stop-at-first-match: true
-
-    # Extractors for the first request in the Digest flow
     extractors:
       - type: regex
         name: realm
         part: header
-        internal: true
+        group: 1
         regex:
           - 'realm="([^"]+)"'
       - type: regex
         name: nonce
         part: header
-        internal: true
+        group: 1
         regex:
           - 'nonce="([^"]+)"'
       - type: regex
         name: qop
         part: header
-        internal: true
+        group: 1
         regex:
           - 'qop="([^"]+)"'
 
-    # Matchers for the second request in the Digest flow
+  - raw:
+      - |
+        GET /cgi-bin/get?system.access_level HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Digest username="admin", realm="{{realm}}", nonce="{{nonce}}", uri="/cgi-bin/get?system.access_level", qop={{qop}}, nc=00000001, cnonce="{{rand_base(8)}}", response="{{md5(md5('admin:{{realm}}:admin') + ':' + nonce + ':' + '00000001' + ':' + rand_base(8) + ':' + qop + ':' + md5('GET:/cgi-bin/get?system.access_level'))}}"
+
     matchers-condition: and
     matchers:
       - type: status

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -1,64 +1,86 @@
-id: pelco-sarix-default-login-digest
+id: pelco-sarix-default-login-combined
 
 info:
-  name: Pelco Sarix - Default Login
-  author: tdiderich
+  name: Pelco Sarix - Default Login (Basic and Digest)
+  author: tdiderich (modified by Gemini)
   severity: high
   description: |
-    Pelco Sarix camera default login credentials (admin/admin) were discovered using Digest Authentication.
+    Pelco Sarix camera default login credentials (admin/admin) were discovered.
+    This template attempts both Basic and Digest authentication methods.
   reference:
     - https://www.pelco.com/
   classification:
     cwe-id: CWE-798
   metadata:
     verified: true
-    max-request: 2
+    max-request: 3 # 1 for Basic, 2 for Digest
     vendor: pelco
     product: sarix
-    runzero-match: asset["hw"] matches "(i)Pelco Sarix"
   tags: pelco,sarix,default-login
 
 http:
+  # --- Block 1: Basic Authentication Attempt ---
+  # This will be tried first. It's for devices that don't issue a 401 challenge.
+  - raw:
+      - |
+        GET /cgi-bin/get?system.access_level HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Basic {{base64('admin' + ':' + 'admin')}}
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "system.access_level"
+
+  # --- Block 2: Digest Authentication Attempt ---
+  # This will run if the first block fails. It handles the 401 challenge/response.
   - raw:
       - |
         GET /cgi-bin/get?system.access_level HTTP/1.1
         Host: {{Hostname}}
 
-    matchers:
-      - type: status
-        status:
-          - 401
-      - type: word
-        words:
-          - "WWW-Authenticate: Digest"
-        part: header
-
-    extractors:
-      - type: regex
-        name: realm
-        part: header
-        group: 1
-        regex:
-          - 'realm="([^"]+)"'
-      - type: regex
-        name: nonce
-        part: header
-        group: 1
-        regex:
-          - 'nonce="([^"]+)"'
-      - type: regex
-        name: qop
-        part: header
-        group: 1
-        regex:
-          - 'qop="([^"]+)"'
-
-  - raw:
       - |
         GET /cgi-bin/get?system.access_level HTTP/1.1
         Host: {{Hostname}}
         Authorization: Digest username="admin", realm="{{realm}}", nonce="{{nonce}}", uri="/cgi-bin/get?system.access_level", qop={{qop}}, nc=00000001, cnonce="{{rand_base(8)}}", response="{{md5(md5('admin:{{realm}}:admin') + ':' + nonce + ':' + '00000001' + ':' + rand_base(8) + ':' + qop + ':' + md5('GET:/cgi-bin/get?system.access_level'))}}"
 
+    attack: pitchfork
+    payloads:
+      # Dummy payload to satisfy the attack type, values are not used in the digest flow
+      username:
+        - admin
+      password:
+        - admin
+
+    stop-at-first-match: true
+
+    # Extractors for the first request in the Digest flow
+    extractors:
+      - type: regex
+        name: realm
+        part: header
+        internal: true
+        regex:
+          - 'realm="([^"]+)"'
+      - type: regex
+        name: nonce
+        part: header
+        internal: true
+        regex:
+          - 'nonce="([^"]+)"'
+      - type: regex
+        name: qop
+        part: header
+        internal: true
+        regex:
+          - 'qop="([^"]+)"'
+
+    # Matchers for the second request in the Digest flow
     matchers-condition: and
     matchers:
       - type: status

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -2,7 +2,7 @@ id: pelco-sarix-default-login
 
 info:
   name: Pelco Sarix - Default Login
-  author: Gemini
+  author: tdiderich
   severity: high
   description: |
     Pelco Sarix camera default login credentials (admin/admin) were discovered.
@@ -44,17 +44,13 @@ http:
       - type: status
         status:
           - 302
+          - 200
+        condition: or
 
       # The redirect location should be to the post-login page.
       - type: word
         part: header
         words:
-          - "Location: /index_register.html"
-          - "Location: /index.html"
+          - "/index_register.html"
+          - "/index.html"
         condition: or
-
-      # A session cookie is usually set upon successful login.
-      - type: word
-        part: header
-        words:
-          - "Set-Cookie:"

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     Pelco Sarix camera default login credentials (admin/admin) were discovered using Digest Authentication.
   reference:
-    - https://www.pelco.com/
+    - hhttps://support.pelco.com/s/article/Default-passwords-and-usernames-for-Digital-Sentry-DX-Endura-Sarix-and-VideoXpert-components-1538586718306?language=en_US
   classification:
     cwe-id: CWE-798
   metadata:

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -21,7 +21,7 @@ info:
 http:
   - raw:
       - |
-        GET /cgi-bin/get? HTTP/1.1
+        GET /cgi-bin/get?system.access_level HTTP/1.1
         Host: {{Hostname}}
         Authorization: Basic {{base64(username + ":" + password)}}
 

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -21,11 +21,9 @@ info:
 http:
   - raw:
       - |
-        POST /login/login.html HTTP/1.1
+        GET /cgi-bin/get? HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-
-        username={{username}}&password={{password}}
+        Authorization: Basic {{base64(username + ":" + password)}}
 
     attack: pitchfork
     payloads:
@@ -39,17 +37,11 @@ http:
 
     matchers-condition: and
     matchers:
-      # A 302 redirect is the most likely indicator of a successful login submission.
       - type: status
         status:
-          - 302
           - 200
-        condition: or
 
-      # The redirect location should be to the post-login page.
       - type: word
-        part: header
+        part: body
         words:
-          - "/index_register.html"
-          - "/index.html"
-        condition: or
+          - "system.access_level"

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -7,7 +7,7 @@ info:
   description: |
     Pelco Sarix camera default login credentials (admin/admin) were discovered using Digest Authentication.
   reference:
-    - hhttps://support.pelco.com/s/article/Default-passwords-and-usernames-for-Digital-Sentry-DX-Endura-Sarix-and-VideoXpert-components-1538586718306?language=en_US
+    - https://support.pelco.com/s/article/Default-passwords-and-usernames-for-Digital-Sentry-DX-Endura-Sarix-and-VideoXpert-components-1538586718306?language=en_US
   classification:
     cwe-id: CWE-798
   metadata:

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -1,0 +1,60 @@
+id: pelco-sarix-default-login
+
+info:
+  name: Pelco Sarix - Default Login
+  author: Gemini
+  severity: high
+  description: |
+    Pelco Sarix camera default login credentials (admin/admin) were discovered.
+  reference:
+    - https://www.pelco.com/
+  classification:
+    cwe-id: CWE-798
+  metadata:
+    verified: true
+    max-request: 1
+    vendor: pelco
+    product: sarix
+    runzero-match: asset["hw"] matches "(i)Pelco Sarix"
+  tags: pelco,sarix,default-login
+
+http:
+  - raw:
+      - |
+        POST /login/login.html HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{username}}&password={{password}}
+
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+      password:
+        - admin
+
+    stop-at-first-match: true
+    # Do not follow redirects automatically, as we want to inspect the Location header.
+    host-redirects: false
+
+    matchers-condition: and
+    matchers:
+      # A 302 redirect is the most likely indicator of a successful login submission.
+      - type: status
+        status:
+          - 302
+
+      # The redirect location should be to the post-login page.
+      - type: word
+        part: header
+        words:
+          - "Location: /index_register.html"
+          - "Location: /index.html"
+        condition: or
+
+      # A session cookie is usually set upon successful login.
+      - type: word
+        part: header
+        words:
+          - "Set-Cookie:"

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -1,18 +1,18 @@
-id: pelco-sarix-default-login
+id: pelco-sarix-default-login-digest
 
 info:
   name: Pelco Sarix - Default Login
   author: tdiderich
   severity: high
   description: |
-    Pelco Sarix camera default login credentials (admin/admin) were discovered.
+    Pelco Sarix camera default login credentials (admin/admin) were discovered using Digest Authentication.
   reference:
     - https://www.pelco.com/
   classification:
     cwe-id: CWE-798
   metadata:
     verified: true
-    max-request: 1
+    max-request: 2
     vendor: pelco
     product: sarix
     runzero-match: asset["hw"] matches "(i)Pelco Sarix"
@@ -23,24 +23,47 @@ http:
       - |
         GET /cgi-bin/get?system.access_level HTTP/1.1
         Host: {{Hostname}}
-        Authorization: Basic {{base64(username + ":" + password)}}
 
-    attack: pitchfork
-    payloads:
-      username:
-        - admin
-      password:
-        - admin
+    matchers:
+      - type: status
+        status:
+          - 401
+      - type: word
+        words:
+          - "WWW-Authenticate: Digest"
+        part: header
 
-    stop-at-first-match: true
-    host-redirects: true
+    extractors:
+      - type: regex
+        name: realm
+        part: header
+        group: 1
+        regex:
+          - 'realm="([^"]+)"'
+      - type: regex
+        name: nonce
+        part: header
+        group: 1
+        regex:
+          - 'nonce="([^"]+)"'
+      - type: regex
+        name: qop
+        part: header
+        group: 1
+        regex:
+          - 'qop="([^"]+)"'
+
+  - raw:
+      - |
+        GET /cgi-bin/get?system.access_level HTTP/1.1
+        Host: {{Hostname}}
+        Authorization: Digest username="admin", realm="{{realm}}", nonce="{{nonce}}", uri="/cgi-bin/get?system.access_level", qop={{qop}}, nc=00000001, cnonce="{{rand_base(8)}}", response="{{md5(md5('admin:{{realm}}:admin') + ':' + nonce + ':' + '00000001' + ':' + rand_base(8) + ':' + qop + ':' + md5('GET:/cgi-bin/get?system.access_level'))}}"
 
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
-
       - type: word
         part: body
         words:


### PR DESCRIPTION
### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Default credential check for Pelco Sarix added
- Ref doc: hhttps://support.pelco.com/s/article/Default-passwords-and-usernames-for-Digital-Sentry-DX-Endura-Sarix-and-VideoXpert-components-1538586718306?language=en_US

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)