### PR TITLE
Improve predicate: Avaya Phone Web Interface - Default Login

### DIFF
--- a/http/default-logins/avaya-phone-default-login.yaml
+++ b/http/default-logins/avaya-phone-default-login.yaml
@@ -10,7 +10,7 @@ info:
   classification:
     cwe-id: CWE-1392
   metadata:
-    runzero-match: service["http.body"] matches "(?i)Avaya J179 Phone"
+    runzero-match: service["http.body"] matches `(?i)Avaya J1\d9 Phone`
     max-requests: 1
     shodan-query: html:"Avaya J179 Phone"
     verified: true


### PR DESCRIPTION
Expands the `runzero-match` predicate to match more J100 series phones. The [J100 Series IP Phone models](http://documentation.avaya.com/bundle/InstallandadminJ100seriesIPPhone_r4.1.x/page/J100_Series_IP_Phone_models.html) document lists: J129, J139, J159, J169, J179, and J189.
This is a follow-up to a [comment](https://github.com/runZeroInc/nuclei-templates/pull/252#discussion_r3140473533) I left on #252.

## Shodan queries
* `http.html:"Avaya J129 Phone"` => 3
* `http.html:"Avaya J139 Phone"` => 39
* `http.html:"Avaya J159 Phone"` => 0
* `http.html:"Avaya J169 Phone"` => 1
* `http.html:"Avaya J179 Phone"` => 91
* `http.html:"Avaya J189 Phone"` => 0