### PR TITLE
Fixed pelco-sarix-default-login-digest: add missing matchers-condition and on first request

### DIFF
--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -23,7 +23,7 @@ http:
       - |
         GET /cgi-bin/get?system.access_level HTTP/1.1
         Host: {{Hostname}}
-
+    matchers-condition: and  
     matchers:
       - type: status
         status:

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -23,7 +23,7 @@ http:
       - |
         GET /cgi-bin/get?system.access_level HTTP/1.1
         Host: {{Hostname}}
-    matchers-condition: and  
+    matchers-condition: and
     matchers:
       - type: status
         status:

--- a/http/default-logins/pelco/pelco-sarix-default-login.yaml
+++ b/http/default-logins/pelco/pelco-sarix-default-login.yaml
@@ -23,6 +23,7 @@ http:
       - |
         GET /cgi-bin/get?system.access_level HTTP/1.1
         Host: {{Hostname}}
+
     matchers-condition: and
     matchers:
       - type: status


### PR DESCRIPTION
### PR Information

- Fixed false positive in `pelco-sarix-default-login-digest` template caused by missing `matchers-condition: and` on the first HTTP request step.
- References: https://support.pelco.com/s/article/Default-passwords-and-usernames-for-Digital-Sentry-DX-Endura-Sarix-and-VideoXpert-components-1538586718306

**Root cause:**
The first `raw` request block was missing `matchers-condition: and`, causing Nuclei to evaluate matchers with default OR logic. A `401` status response alone was sufficient to pass step 1, trigger the variable extractors (`realm`, `nonce`, `qop`), and ultimately fire the finding — regardless of the authentication scheme advertised by the server.

Any host returning `HTTP 401` with `WWW-Authenticate: Basic` on `/cgi-bin/get?system.access_level` would generate a false positive. No Pelco Sarix device or Digest authentication is required.

**Fix:**
Added `matchers-condition: and` to the first request block to enforce that both conditions must be true before proceeding:
- Status `401`
- `WWW-Authenticate: Digest` present in response headers

### Template validation

- [ ] Validated with a host running a vulnerable version and/or configuration (True Positive)
- [x] Validated with a host running a patched version and/or configuration (avoid False Positive)

#### Additional Details

False positive confirmed via `nuclei -debug` on a host returning `WWW-Authenticate: Basic` on the target path. The `:status-1` suffix in Nuclei output confirms only the status matcher fired — the Digest word matcher did not — yet the template still triggered due to missing `matchers-condition: and`.

**Redacted debug output:**
```
Www-Authenticate: Basic realm="[redacted]"
[pelco-sarix-default-login-digest:status-1] [http] [high] https://[redacted]/cgi-bin/get?system.access_level
```

**Shodan query for surface validation:**
```
http.url:"/cgi-bin/get?system.access_level"
```
