### PR TITLE
Improve predicate: Zebra printers

### DIFF
--- a/http/default-logins/zebra/zebra-printer-default-login.yaml
+++ b/http/default-logins/zebra/zebra-printer-default-login.yaml
@@ -6,7 +6,7 @@ info:
   description: |
     Zebra default login credentials was discovered.
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Zebra"})
+    runzero-match: any(each(service["html.titles"]), {# matches "Zebra"}) || service["http.body"] matches "Zebra Technologies"
     max-request: 4
     shodan-query: title:"Zebra"
     verified: true

--- a/http/iot/zebra-printer-detect.yaml
+++ b/http/iot/zebra-printer-detect.yaml
@@ -10,6 +10,7 @@ info:
   classification:
     cpe: cpe:2.3:o:zebra:zt220_firmware:*:*:*:*:*:*:*:*
   metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Zebra"}) || service["http.body"] matches "Zebra Technologies"
     verified: true
     max-request: 1
     vendor: zebra


### PR DESCRIPTION
- Expands the `runzero-match` predicate in `http/default-logins/zebra/zebra-printer-default-login.yaml` to match more printers from Zebra Technologies.
- Adds the improved `runzero-match` predicate to `http/iot/zebra-printer-detect.yaml`
