### PR TITLE
Adjust runzero match for wowza panel

### DIFF
--- a/http/cves/2018/CVE-2018-19365.yaml
+++ b/http/cves/2018/CVE-2018-19365.yaml
@@ -22,7 +22,7 @@ info:
     epss-score: 0.22035
     epss-percentile: 0.97351
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "(?i)manager\" product:\"wowza streaming engine"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Wowza Streaming Engine Manager$"})
     fofa-query: title="manager" product:"wowza streaming engine"
     google-query: intitle:"manager" product:"wowza streaming engine"
     max-request: 1

--- a/http/exposed-panels/wowza-streaming-engine.yaml
+++ b/http/exposed-panels/wowza-streaming-engine.yaml
@@ -7,7 +7,7 @@ info:
   classification:
     cpe: cpe:2.3:a:wowza:streaming_engine:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "(?i)manager"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Wowza Streaming Engine Manager$"})
     fofa-query: title="manager" product:"wowza streaming engine"
     google-query: intitle:"manager" product:"wowza streaming engine"
     max-request: 1


### PR DESCRIPTION
Our previous runzero-match value was a little bit too vague.  This makes it match the title more specifically.
