### PR TITLE
Enhance predicate in apc-pdu-default-login template

### DIFF
--- a/http/default-logins/schneider-electric/apc.yaml
+++ b/http/default-logins/schneider-electric/apc.yaml
@@ -10,7 +10,7 @@ info:
     # User manual with default credentials
     - https://iportal2.schneider-electric.com/Contents/docs/UPS-PMAR-9LLJMN_R0_EN.PDF
   metadata:
-    runzero-match: asset["hw"] matches `Schneider\s+Electric` || asset["os"] matches `Schneider\s+Electric\s+AOS` || any(each(service["html.titles"]), {# matches `APC \| Log On`})
+    runzero-match: (asset["hw"] matches `Schneider\s+Electric` || asset["os"] matches `Schneider\s+Electric\s+AOS`) && any(each(service["html.titles"]), {# matches `APC \| Log On`}) || (any(each(service["html.titles"]), {# matches `Log On`}) && service["http.body"] matches `(?i)class="apclogo"|href="https?://www.apc\.com"`)
   tags: default-login,apc,pdu,runzero
 
 http:
@@ -45,4 +45,3 @@ http:
         part: header
         regex:
           - "Location: .*?/home"
-


### PR DESCRIPTION
### PR Information

Enhances the `runzero-match` for `http/default-logins/schneider-electric/apc.yaml` which was introduced in #45. It appears the title may have changed on some of these shifting from `APC | Log On` to simply `Log On`. In the case of the `Log On` title we will search the body for some APC values that were observed.