### PR TITLE
Bump requirements with 2 updates

### DIFF
--- a/.github/scripts/wordpress-plugins-update-requirements.txt
+++ b/.github/scripts/wordpress-plugins-update-requirements.txt
@@ -2,9 +2,9 @@ beautifulsoup4==4.11.1
 bs4==0.0.1
 certifi==2024.7.4
 charset-normalizer==2.1.1
-idna==3.7
+idna==3.18
 Markdown==3.4.1
-requests==2.33.0
+requests==2.33.1
 soupsieve==2.3.2.post1
 termcolor==2.1.1
 urllib3==2.7.0


### PR DESCRIPTION
Bumps requirements with 2 updates:
* Updates `idna` from 3.7 to 3.18
* Updates `requests` from 2.33.0 to 2.33.1

Tested `wordpress-plugins-update.py` locally with these requirements and it appears to work without issue.