### PR TITLE
Resolved errors in CVE-2025-29635 template

### DIFF
--- a/http/cves/2025/CVE-2025-29635.yaml
+++ b/http/cves/2025/CVE-2025-29635.yaml
@@ -30,7 +30,7 @@ info:
 flow: http(1) && http(2)
 http:
   - host-redirects: true
-    matchers:
+  - matchers:
       - dsl:
           - contains(to_lower(body), 'dir-823')
         internal: true
@@ -41,7 +41,7 @@ http:
         GET / HTTP/1.1
         Host: {{Hostname}}
   - matchers:
-      condition: and
+    - condition: and
       dsl:
         - contains(interactsh_protocol,'dns')
         - status_code == 200


### PR DESCRIPTION
### PR Information

- CVE-2025-29635 template was incorrectly formatted, causing marshaling errors when running `build_nuclei.sh`.  This resolves that error by adding the needed hyphens before `matchers` and `condition`.
- Resolves https://github.com/runZeroInc/platform/issues/26386

#### Additional Details (leave it blank if not applicable)

The template was also in the javascript category, despite being an http template.  I have moved it to the correct directory.

### Additional References:

- [Nuclei Template Creation Guideline](https://docs.projectdiscovery.io/templates/introduction)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)
