### PR TITLE
rejected template CVE-2026-46339

### DIFF
--- a/http/cves/2026/CVE-2026-46339.yaml
+++ b/http/cves/2026/CVE-2026-46339.yaml
@@ -18,7 +18,7 @@ info:
     cve-id: CVE-2026-46339
     cwe-id: CWE-78
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "^9Router"})
+    runzero-review: REJECT/2026-07-15/Writes files to disk
     max-request: 3
     product: 9router
     vendor: decolua


### PR DESCRIPTION
### PR Information

One of the approved templates was writing to disk